### PR TITLE
fix: "sliver" typo

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -15,7 +15,7 @@ export const defaultTiers: Tier[] = [
     preset: presets.medium,
   },
   {
-    title: 'Sliver Sponsors',
+    title: 'Silver Sponsors',
     monthlyDollars: 100,
     preset: presets.large,
   },


### PR DESCRIPTION
This PR fixes a small typo that can be seen on your sponsor image, it says "sliver sponsors" instead of "silver sponsors" (which can be correct but I doubt it's what you meant 😄)