### PR TITLE
fix: handle missing token scopes and document them

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Toolkit for generating sponsors images.
 Create `.env` file with:
 
 ```ini
+; Token requires the `read:user` and `read:org` scopes.
 SPONSORKIT_TOKEN=your_github_token
 SPONSORKIT_LOGIN=your_github_username
 ```

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -17,6 +17,10 @@ export async function fetchSponsors(token: string, login: string): Promise<Spons
         'Content-Type': 'application/json',
       },
     }) as any
+
+    if (data.errors?.[0]?.type === 'INSUFFICIENT_SCOPES')
+      throw new Error('Token is missing the `read:user` and/or `read:org` scopes')
+
     sponsors.push(
       ...(data.data.user.sponsorshipsAsMaintainer.nodes || []),
     )


### PR DESCRIPTION
I was having trouble creating a token with just enough permissions for sponsorkit - it requires `read:user` & `read:org`.
This PR adds a comment in the README and throws an error mentioning them!

Currently if you provide a token without those permissions the cli logs the following:
```bash
SponsorKit v0.0.7

ℹ Fetching sponsorships...                                            01:35:53
TypeError: Cannot read properties of undefined (reading 'user')
    at Object.fetchSponsors (/home/geopjr/.npm/_npx/6d9e562882086ed1/node_modules/sponsorkit/dist/chunks/config.cjs:30:32)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async run (/home/geopjr/.npm/_npx/6d9e562882086ed1/node_modules/sponsorkit/dist/cli.cjs:39:16)
    at async Object.handler (/home/geopjr/.npm/_npx/6d9e562882086ed1/node_modules/sponsorkit/dist/cli.cjs:130:3)
```

<details><summary>GraphQL response when `read:user` is missing</summary>
<p>

```json
{
	"errors": [
		{
			"type": "INSUFFICIENT_SCOPES",
			"locations": [
				{
					"line": 10,
					"column": 9
				}
			],
			"message": "Your token has not been granted the required scopes to execute this query. The 'createdAt' field requires one of the following scopes: ['read:user'], but your token has only been granted the: ['read:org'] scopes. Please modify your token's scopes at: https://github.com/settings/tokens."
		},
		{
			"type": "INSUFFICIENT_SCOPES",
			"locations": [
				{
					"line": 11,
					"column": 9
				}
			],
			"message": "Your token has not been granted the required scopes to execute this query. The 'privacyLevel' field requires one of the following scopes: ['read:user'], but your token has only been granted the: ['read:org'] scopes. Please modify your token's scopes at: https://github.com/settings/tokens."
		}
	]
}
```

</p>
</details>

<details><summary>GraphQL response when `read:org` is missing</summary>
<p>

```json
{
	"errors": [
		{
			"type": "INSUFFICIENT_SCOPES",
			"locations": [
				{
					"line": 21,
					"column": 13
				}
			],
			"message": "Your token has not been granted the required scopes to execute this query. The 'login' field requires one of the following scopes: ['read:org'], but your token has only been granted the: ['user'] scopes. Please modify your token's scopes at: https://github.com/settings/tokens."
		},
		{
			"type": "INSUFFICIENT_SCOPES",
			"locations": [
				{
					"line": 22,
					"column": 13
				}
			],
			"message": "Your token has not been granted the required scopes to execute this query. The 'name' field requires one of the following scopes: ['read:org'], but your token has only been granted the: ['user'] scopes. Please modify your token's scopes at: https://github.com/settings/tokens."
		},
		{
			"type": "INSUFFICIENT_SCOPES",
			"locations": [
				{
					"line": 23,
					"column": 13
				}
			],
			"message": "Your token has not been granted the required scopes to execute this query. The 'avatarUrl' field requires one of the following scopes: ['read:org'], but your token has only been granted the: ['user'] scopes. Please modify your token's scopes at: https://github.com/settings/tokens."
		}
	]
}
```

</p>
</details>

Let me know if I should change the wording of the messages!

(Also thanks for creating this, it's awesome! ✨)