### PR TITLE
chore: update example

### DIFF
--- a/example/sponsor.config.ts
+++ b/example/sponsor.config.ts
@@ -2,7 +2,9 @@
 import { defineConfig, presets } from 'sponsorkit'
 
 export default defineConfig({
-  login: 'antfu',
+  github: {
+    login: 'antfu',
+  },
   tiers: [
     {
       title: 'Backers',


### PR DESCRIPTION
I see `login` updated to `github.login`.

Did you forget to update the example?