### PR TITLE
feat: add OpenCollective provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ SPONSORKIT_GITHUB_LOGIN=your_github_username
 ; Create v2 API key at https://www.patreon.com/portal/registration/register-clients
 ; and use the "Creator’s Access Token".
 SPONSORKIT_PATREON_TOKEN=your_patreon_token
+
+; OpenCollective provider.
+; Create an API key at https://opencollective.com/applications.
+SPONSORKIT_OPENCOLLECTIVE_KEY=your_opencollective_key
+; And provide the ID, slug or GitHub slug of your collective.
+SPONSORKIT_OPENCOLLECTIVE_ID=your_opencollective_collective_id
+; or
+SPONSORKIT_OPENCOLLECTIVE_SLUG=your_opencollective_collective_slug
+; or
+SPONSORKIT_OPENCOLLECTIVE_GH_HANDLE=your_opencollective_collective_github_handle
 ```
 
 > Only one provider is required to be configured.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ SPONSORKIT_GITHUB_LOGIN=your_github_username
 SPONSORKIT_PATREON_TOKEN=your_patreon_token
 
 ; OpenCollective provider.
-; Create an API key at https://opencollective.com/applications.
+; Create an API key at https://opencollective.com/applications
 SPONSORKIT_OPENCOLLECTIVE_KEY=your_opencollective_key
-; And provide the ID, slug or GitHub slug of your collective.
+; and provide the ID, slug or GitHub handle of your collective.
 SPONSORKIT_OPENCOLLECTIVE_ID=your_opencollective_collective_id
 ; or
 SPONSORKIT_OPENCOLLECTIVE_SLUG=your_opencollective_collective_slug

--- a/src/env.ts
+++ b/src/env.ts
@@ -20,6 +20,12 @@ export function loadEnv(): Partial<SponsorkitConfig> {
     patreon: {
       token: process.env.SPONSORKIT_PATREON_TOKEN,
     },
+    opencollective: {
+      key: process.env.SPONSORKIT_OPENCOLLECTIVE_KEY || process.env.OPENCOLLECTIVE_KEY,
+      id: process.env.SPONSORKIT_OPENCOLLECTIVE_ID || process.env.OPENCOLLECTIVE_ID,
+      slug: process.env.SPONSORKIT_OPENCOLLECTIVE_SLUG || process.env.OPENCOLLECTIVE_SLUG,
+      githubHandle: process.env.SPONSORKIT_OPENCOLLECTIVE_GH_HANDLE || process.env.OPENCOLLECTIVE_GH_HANDLE,
+    },
     outputDir: process.env.SPONSORKIT_DIR,
   }
 

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,12 +1,14 @@
 import type { Provider, ProviderName, SponsorkitConfig } from '../types'
 import { GitHubProvider } from './github'
 import { PatreonProvider } from './patreon'
+import { OpenCollectiveProvider } from './opencollective'
 
 export * from './github'
 
 export const ProvidersMap = {
   github: GitHubProvider,
   patreon: PatreonProvider,
+  opencollective: OpenCollectiveProvider,
 }
 
 export function guessProviders(config: SponsorkitConfig) {
@@ -16,6 +18,9 @@ export function guessProviders(config: SponsorkitConfig) {
 
   if (config.patreon && config.patreon.token)
     items.push('patreon')
+
+  if (config.opencollective && (config.opencollective.id || config.opencollective.slug || config.opencollective.githubHandle))
+    items.push('opencollective')
 
   // fallback
   if (!items.length)

--- a/src/providers/opencollective.ts
+++ b/src/providers/opencollective.ts
@@ -1,0 +1,99 @@
+import { $fetch } from 'ohmyfetch'
+import type { Provider, Sponsorship } from '../types'
+
+const API = 'https://api.opencollective.com/graphql/v2/'
+const graphql = String.raw
+
+export const OpenCollectiveProvider: Provider = {
+  name: 'opencollective',
+  fetchSponsors(config) {
+    return fetchOpenCollectiveSponsors(
+      config.opencollective?.key,
+      config.opencollective?.id,
+      config.opencollective?.slug,
+      config.opencollective?.githubHandle,
+    )
+  },
+}
+
+export async function fetchOpenCollectiveSponsors(key?: string, id?: string, slug?: string, githubHandle?: string): Promise<Sponsorship[]> {
+  if (!key)
+    throw new Error('OpenCollective api key is required')
+  if (!slug && !id && !githubHandle)
+    throw new Error('OpenCollective collective id or slug or GitHub handle is required')
+
+  const sponsors: any[] = []
+  let offset
+  offset = 0
+
+  do {
+    const query = makeQuery(id, slug, githubHandle, offset)
+    const data = await $fetch(API, {
+      method: 'POST',
+      body: { query },
+      headers: {
+        'Api-Key': `${key}`,
+        'Content-Type': 'application/json',
+      },
+    }) as any
+
+    sponsors.push(
+      ...(data.data.collective.members.nodes || []),
+    )
+    if (data.data.collective.members.nodes.length !== 0)
+      offset += data.data.collective.members.nodes.length
+    else
+      offset = undefined
+  } while (offset)
+
+  const processed = sponsors
+    .map((raw: any): Sponsorship => ({
+      sponsor: {
+        type: raw.account.type === 'INDIVIDUAL' ? 'User' : 'Organization',
+        login: raw.account.slug,
+        name: raw.account.name,
+        avatarUrl: raw.account.imageUrl,
+        linkUrl: `https://opencollective.com/${raw.account.slug}`,
+      },
+      isOneTime: !raw.tier || raw.tier.type === 'DONATION',
+      monthlyDollars: raw.totalDonations.value,
+      privacyLevel: !raw.tier || raw.account.isIncognito ? 'PRIVATE' : 'PUBLIC',
+      tierName: !raw.tier ? '' : raw.tier.name,
+      createdAt: raw.createdAt,
+    }))
+
+  return processed
+}
+
+export function makeQuery(id?: string, slug?: string, githubHandle?: string, offset?: number) {
+  return graphql`{
+  collective(${id ? `id: "${id}", ` : ''}${slug ? `slug: "${slug}", ` : ''}${githubHandle ? `githubHandle: "${githubHandle}", ` : ''}, throwIfMissing: true) {
+    members(limit: 100${offset ? ` offset: ${offset}` : ''} role: [BACKER]) {
+      offset
+      limit
+      totalCount
+      nodes {
+        id
+        role
+        createdAt
+        totalDonations {
+          value
+          currency
+          valueInCents
+        }
+        tier {
+          name
+          type
+        }
+        account {
+          name
+          slug
+          type
+          isIncognito
+          imageUrl(height: 460, format: png)
+        }
+      }
+    }
+  }
+}`
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,7 @@ export interface Sponsorship {
 
 export type OutputFormat = 'svg' | 'png' | 'json'
 
-export type ProviderName = 'github' | 'patreon'
+export type ProviderName = 'github' | 'patreon' | 'opencollective'
 
 export interface ProvidersConfig {
   github?: {
@@ -80,6 +80,32 @@ export interface ProvidersConfig {
      * @deprecated It's not recommended set this value directly, pass from env or use `.env` file.
      */
     token?: string
+  }
+  opencollective?: {
+    /**
+     * Api key of your OpenCollective account.
+     *
+     * Will read from `SPONSORKIT_OPENCOLLECTIVE_KEY` environment variable if not set.
+     */
+    key?: string
+    /**
+     * The id of your collective.
+     *
+     * Will read from `SPONSORKIT_OPENCOLLECTIVE_ID` environment variable if not set.
+     */
+    id?: string
+    /**
+     * The slug of your collective.
+     *
+     * Will read from `SPONSORKIT_OPENCOLLECTIVE_SLUG` environment variable if not set.
+     */
+    slug?: string
+    /**
+     * The GitHub handle of your collective.
+     *
+     * Will read from `SPONSORKIT_OPENCOLLECTIVE_GH_HANDLE` environment variable if not set.
+     */
+    githubHandle?: string
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,8 @@ export interface ProvidersConfig {
      * Api key of your OpenCollective account.
      *
      * Will read from `SPONSORKIT_OPENCOLLECTIVE_KEY` environment variable if not set.
+     *
+     * @deprecated It's not recommended set this value directly, pass from env or use `.env` file.
      */
     key?: string
     /**


### PR DESCRIPTION
This PR adds an OpenCollective provider.

## Blocking

~~OpenCollective returns an avatar url even if the user doesn't have one (which fails on `resolveAvatars`), a default one should be provided instead.~~

## Concerns

- OpenCollective suppots multiple currencies which might confuse users since the key is called `monthlyDollars`
- OpenCollective graphql api is not fully documented (eg. pagination)

#

- [OpenCollective Graphql docs](https://graphql-docs-v2.opencollective.com/)
- [OpenCollective API key page](https://opencollective.com/applications)

Output (on `babel` with a 10 backers hard limit):

![sponsors of babel on opencollective](https://user-images.githubusercontent.com/18014039/156973436-30412ef4-9878-4b68-8dfa-92728823f133.png)

closes: #8 