### PR TITLE
feat: add patreon provider

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -16,6 +16,9 @@ export function loadEnv(): Partial<SponsorkitConfig> {
       login: process.env.SPONSORKIT_GITHUB_LOGIN || process.env.GITHUB_LOGIN || getDeprecatedEnv('SPONSORKIT_LOGIN', 'SPONSORKIT_GITHUB_LOGIN'),
       token: process.env.SPONSORKIT_GITHUB_TOKEN || process.env.GITHUB_TOKEN || getDeprecatedEnv('SPONSORKIT_TOKEN', 'SPONSORKIT_GITHUB_TOKEN'),
     },
+    patreon: {
+      token: process.env.SPONSORKIT_PATREON_TOKEN,
+    },
     outputDir: process.env.SPONSORKIT_DIR,
   }
 

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,10 +1,12 @@
 import type { Provider, ProviderName, SponsorkitConfig } from '../types'
 import { GitHubProvider } from './github'
+import { PatreonProvider } from './patreon'
 
 export * from './github'
 
 export const ProvidersMap = {
   github: GitHubProvider,
+  patreon: PatreonProvider,
 }
 
 export function guessProviders(config: SponsorkitConfig) {
@@ -12,6 +14,9 @@ export function guessProviders(config: SponsorkitConfig) {
   if (config.github && config.github.login)
     items.push('github')
 
+  if (config.patreon && config.patreon.token)
+    items.push('patreon')
+    
   // fallback
   if (!items.length)
     items.push('github')

--- a/src/providers/patreon.ts
+++ b/src/providers/patreon.ts
@@ -1,0 +1,72 @@
+import { $fetch } from 'ohmyfetch'
+import type { Provider, Sponsorship } from '../types'
+
+export const PatreonProvider: Provider = {
+  name: 'patreon',
+  fetchSponsors(config) {
+    return fetchPatreonSponsors(config.patreon?.token || config.token!)
+  },
+}
+
+export async function fetchPatreonSponsors(token: string): Promise<Sponsorship[]> {
+  if (!token) throw new Error('Patreon token is required')
+
+  // Get current authenticated user's campaign ID (Everyone has one default campaign)
+  const userData = await $fetch(
+    'https://www.patreon.com/api/oauth2/api/current_user/campaigns?include=null',
+    {
+      method: 'GET',
+      headers: {
+        'Authorization': `bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      responseType: 'json',
+    },
+  )
+  const userCampaignId = userData.data[0].id
+
+  const sponsors: any[] = []
+  let sponsorshipApi = `https://www.patreon.com/api/oauth2/api/campaigns/${userCampaignId}/pledges?include=patron.null,reward.null&page%5Bcount%5D=100`
+  do {
+    // Get pledges from the campaign
+    const sponsorshipData = await $fetch(sponsorshipApi, {
+      method: 'GET',
+      headers: {
+        'Authorization': `bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      responseType: 'json',
+    })
+    sponsors.push(
+      ...sponsorshipData.data.map((pledge: any) => ({
+        pledge,
+        patron: sponsorshipData.included.find(
+          (v: any) => v.id === pledge.relationships.patron.data.id,
+        ),
+        reward: sponsorshipData.included.find(
+          (v: any) => v.id === pledge.relationships.reward.data.id,
+        ),
+      })),
+    )
+    sponsorshipApi = sponsorshipData.links.next
+  } while (sponsorshipApi)
+
+  const processed = sponsors.map(
+    (raw: any): Sponsorship => ({
+      sponsor: {
+        avatarUrl: raw.patron.attributes.image_url,
+        login: raw.patron.attributes.first_name,
+        name: raw.patron.attributes.full_name,
+        type: 'User', // Patreon only support user
+        linkUrl: raw.patron.attributes.url,
+      },
+      isOneTime: false, // One-time pledges not supported
+      monthlyDollars: Math.floor(raw.pledge.attributes.amount_cents / 100),
+      privacyLevel: 'PUBLIC', // Patreon is all public
+      tierName: raw.reward.attributes.title,
+      createdAt: raw.pledge.attributes.created_at,
+    }),
+  )
+
+  return processed
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,7 @@ export interface Sponsorship {
 
 export type OutputFormat = 'svg' | 'png' | 'json'
 
-export type ProviderName = 'github'
+export type ProviderName = 'github' | 'patreon'
 
 export interface ProvidersConfig {
   github?: {
@@ -59,6 +59,16 @@ export interface ProvidersConfig {
      * GitHub Token that have access to your sponsorships.
      *
      * Will read from `SPONSORKIT_TOKEN` environment variable if not set.
+     *
+     * @deprecated It's not recommended set this value directly, pass from env or use `.env` file.
+     */
+    token?: string
+  }
+  patreon?: {
+    /**
+     * Patreon Token that have access to your sponsorships.
+     *
+     * Will read from `SPONSORKIT_PATREON_TOKEN` environment variable if not set.
      *
      * @deprecated It's not recommended set this value directly, pass from env or use `.env` file.
      */


### PR DESCRIPTION
Close #7

# Result

(Using custom sponsorkit.config.js)

```
SponsorKit v0.3.2

[sponsorkit] env.SPONSORKIT_LOGIN is deprecated, use env.SPONSORKIT_GITHUB_LOGIN instead
[sponsorkit] env.SPONSORKIT_TOKEN is deprecated, use env.SPONSORKIT_GITHUB_TOKEN instead
ℹ Fetching sponsorships from patreon...                                                                     13:55:16
✔ 2 sponsorships fetched from patreon                                                                       13:55:18
ℹ Resolving avatars...                                                                                      13:55:18
✔ Avatars resolved                                                                                          13:55:18
✔ Wrote to ./sponsorkit/sponsors.json                                                                       13:55:18
ℹ Composing SVG...                                                                                          13:55:18
✔ Wrote to ./sponsorkit/sponsors.svg                                                                        13:55:18
✔ Wrote to ./sponsorkit/sponsors.png                                                                        13:55:19
```

![sponsors](https://user-images.githubusercontent.com/34116392/165891907-f77e837e-88c5-4a77-9d3d-e3d99dfe80ae.svg)

# Notes

1. I left the `[sponsorkit] env.SPONSORKIT_LOGIN is deprecated, use env.SPONSORKIT_GITHUB_LOGIN instead` as refactoring it made the PR complex. Might be better to cut a minor and remove the deprecated API.
2. Added a deprecated `patreon.token` property to `ProvidersConfig` interface so types work in `src/env.ts`. We could also deprecate the `providers` config entirely?
3. Hopefully I format the code right


