### PR TITLE
feat: support GitHub organization account

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ export default defineConfig({
   // Providers configs
   github: {
     login: 'antfu',
+    type: 'user',
   },
 
   // Rendering configs

--- a/src/env.ts
+++ b/src/env.ts
@@ -15,6 +15,7 @@ export function loadEnv(): Partial<SponsorkitConfig> {
     github: {
       login: process.env.SPONSORKIT_GITHUB_LOGIN || process.env.GITHUB_LOGIN || getDeprecatedEnv('SPONSORKIT_LOGIN', 'SPONSORKIT_GITHUB_LOGIN'),
       token: process.env.SPONSORKIT_GITHUB_TOKEN || process.env.GITHUB_TOKEN || getDeprecatedEnv('SPONSORKIT_TOKEN', 'SPONSORKIT_GITHUB_TOKEN'),
+      type: process.env.SPONSORKIT_GITHUB_TYPE,
     },
     patreon: {
       token: process.env.SPONSORKIT_PATREON_TOKEN,

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,17 +52,24 @@ export interface ProvidersConfig {
     /**
      * User id of your GitHub account.
      *
-     * Will read from `SPONSORKIT_LOGIN` environment variable if not set.
+     * Will read from `SPONSORKIT_GITHUB_LOGIN` environment variable if not set.
      */
     login?: string
     /**
      * GitHub Token that have access to your sponsorships.
      *
-     * Will read from `SPONSORKIT_TOKEN` environment variable if not set.
+     * Will read from `SPONSORKIT_GITHUB_TOKEN` environment variable if not set.
      *
      * @deprecated It's not recommended set this value directly, pass from env or use `.env` file.
      */
     token?: string
+    /**
+     * The account type for sponsorships.
+     * 
+     * Possible values are `user`(default) and `organization`.
+     * Will read from `SPONSORKIT_GITHUB_TYPE` environment variable if not set.
+     */
+    type?: string
   }
   patreon?: {
     /**


### PR DESCRIPTION
GitHub organization also implements `Sponsorable` interfaces in GraphQL, so we only need to change the top data type.