### PR TITLE
fix: should not appear deprecated warning

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -3,7 +3,7 @@ import type { SponsorkitConfig } from './types'
 
 function getDeprecatedEnv(name: string, replacement: string) {
   const value = process.env[name]
-  if (value !== null)
+  if (value)
     console.warn(`[sponsorkit] env.${name} is deprecated, use env.${replacement} instead`)
   return value
 }


### PR DESCRIPTION
### Description

I used the Patreon provider for SponsorKit, not adding any GitHub tokens (no `SPONSORKIT_LOGIN` and `SPONSORKIT_GITHUB_LOGIN`), but show the warning on build time:

```
[sponsorkit] env.SPONSORKIT_LOGIN is deprecated, use env.SPONSORKIT_GITHUB_LOGIN instead
```

Because the `getDeprecatedEnv('SPONSORKIT_LOGIN', 'SPONSORKIT_GITHUB_LOGIN')` using `const value = process.env[name]` to get the global variable, the global variable is a string or `undefined`, if the variable is not found is return the `undefined`. But it is not equal to `null`, so the deprecation warning appears when the variable is equal to `undefined`.

https://github.com/antfu/sponsorkit/blob/0c285ea3dd80fed581ab228b9d021ab83554908a/src/env.ts#L4-L9

So this PR resolved the issue.