### PR TITLE
feat: fallback avatar

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,10 @@ cli.command(
       type: 'number',
       default: 800,
     })
+    .option('fallbackAvatar', {
+      type: 'string',
+      alias: 'fallback',
+    })
     .option('force', {
       alias: 'f',
       default: false,

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -6,5 +6,5 @@ const fallback = `
     <path fill="#636e7b" fill-rule="evenodd" d="M81.85 53.56a14.13 14.13 0 1 1-28.25 0 14.13 14.13 0 0 1 28.25 0zm.35 17.36a22.6 22.6 0 1 0-28.95 0 33.92 33.92 0 0 0-19.38 29.05 4.24 4.24 0 0 0 8.46.4 25.43 25.43 0 0 1 50.8 0 4.24 4.24 0 1 0 8.46-.4 33.93 33.93 0 0 0-19.4-29.05z"/>
 </svg>
 `
-const fallbackPng = svgToPng(fallback)
-export default fallbackPng
+
+export const FALLBACK_AVATAR = svgToPng(fallback)

--- a/src/fallback.ts
+++ b/src/fallback.ts
@@ -1,0 +1,10 @@
+import { svgToPng } from './image'
+
+const fallback = `
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 135.47 135.47">
+    <path fill="#2d333b" stroke="#000" stroke-linejoin="round" stroke-width=".32" d="M.16.16h135.15v135.15H.16z" paint-order="stroke markers fill"/>
+    <path fill="#636e7b" fill-rule="evenodd" d="M81.85 53.56a14.13 14.13 0 1 1-28.25 0 14.13 14.13 0 0 1 28.25 0zm.35 17.36a22.6 22.6 0 1 0-28.95 0 33.92 33.92 0 0 0-19.38 29.05 4.24 4.24 0 0 0 8.46.4 25.43 25.43 0 0 1 50.8 0 4.24 4.24 0 1 0 8.46-.4 33.93 33.93 0 0 0-19.4-29.05z"/>
+</svg>
+`
+const fallbackPng = svgToPng(fallback)
+export default fallbackPng

--- a/src/image.ts
+++ b/src/image.ts
@@ -4,9 +4,9 @@ import imageDataURI from 'image-data-uri'
 import sharp from 'sharp'
 import type { Sponsorship } from './types'
 
-export async function resolveAvatars(ships: Sponsorship[]) {
+export async function resolveAvatars(ships: Sponsorship[], fallback: Buffer) {
   return Promise.all(ships.map(async (ship) => {
-    const data = await $fetch(ship.sponsor.avatarUrl, { responseType: 'arrayBuffer' })
+    const data = await $fetch(ship.sponsor.avatarUrl, { responseType: 'arrayBuffer' }).catch(() => fallback)
     const radius = ship.sponsor.type === 'User' ? 0.5 : 0.15
     ship.sponsor.avatarUrlHighRes = await imageDataURI.encode(await round(data, radius, 120), 'PNG')
     ship.sponsor.avatarUrlMediumRes = await imageDataURI.encode(await round(data, radius, 80), 'PNG')

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,7 +9,7 @@ import { SvgComposer } from './svg'
 import { presets } from './presets'
 import type { SponsorkitConfig, Sponsorship } from './types'
 import { guessProviders, resolveProviders } from './providers'
-import defaultFallbackAvatar from './fallback'
+import { FALLBACK_AVATAR } from './fallback'
 
 function r(path: string) {
   return `./${relative(process.cwd(), path)}`
@@ -21,7 +21,7 @@ export async function run(inlineConfig?: SponsorkitConfig, t = consola) {
   const config = await loadConfig(inlineConfig)
   const dir = resolve(process.cwd(), config.outputDir)
   const cacheFile = resolve(dir, config.cacheFile)
-  const fallbackAvatar = await (config.fallbackAvatar ? fs.readFile(resolve(process.cwd(), config.fallbackAvatar)) : defaultFallbackAvatar)
+  const fallbackAvatar = await (config.fallbackAvatar ? fs.readFile(resolve(process.cwd(), config.fallbackAvatar)) : FALLBACK_AVATAR)
 
   const providers = resolveProviders(config.providers || guessProviders(config))
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,6 +9,7 @@ import { SvgComposer } from './svg'
 import { presets } from './presets'
 import type { SponsorkitConfig, Sponsorship } from './types'
 import { guessProviders, resolveProviders } from './providers'
+import defaultFallbackAvatar from './fallback'
 
 function r(path: string) {
   return `./${relative(process.cwd(), path)}`
@@ -20,6 +21,7 @@ export async function run(inlineConfig?: SponsorkitConfig, t = consola) {
   const config = await loadConfig(inlineConfig)
   const dir = resolve(process.cwd(), config.outputDir)
   const cacheFile = resolve(dir, config.cacheFile)
+  const fallbackAvatar = await (config.fallbackAvatar ? fs.readFile(resolve(process.cwd(), config.fallbackAvatar)) : defaultFallbackAvatar)
 
   const providers = resolveProviders(config.providers || guessProviders(config))
 
@@ -34,7 +36,7 @@ export async function run(inlineConfig?: SponsorkitConfig, t = consola) {
     }
 
     t.info('Resolving avatars...')
-    await resolveAvatars(allSponsors)
+    await resolveAvatars(allSponsors, fallbackAvatar)
     t.success('Avatars resolved')
 
     await fs.ensureDir(dirname(cacheFile))

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,6 +152,11 @@ export interface SponsorkitConfig extends ProvidersConfig {
   width?: number
 
   /**
+   * Path to fallback avatar.
+   */
+  fallbackAvatar?: string
+
+  /**
    * Path to cache file
    *
    * @default './sponsorkit/.cache.json'


### PR DESCRIPTION
### Description

This PR adds a fallback avatar as well as an option to configure it. (Following the comment at https://github.com/antfu/sponsorkit/pull/10#issuecomment-1226836097)

### Linked Issues

#11 

### Additional context

- Avatar copyright
The icon is the one GitHub uses for "private sponsors". I don't think there's a license issue but if there is, I can quickly make a different one in inkscape (circle + half circle)
![image of a generic person icon (a circle on top of half circle) in grey with a darker grey background](https://user-images.githubusercontent.com/18014039/186719014-404a64e4-cbe6-4de3-aa7b-2a7b5d1d493e.png)

- Config
The current config option allows the user to replace the avatar with another *bitmap*. If that's too much, I can replace it with a config option to replace the default fallback icon's colors instead.

closes: #11
