### PR TITLE
fix: filter decline payment users in Patreon provider

### DIFF
--- a/src/providers/patreon.ts
+++ b/src/providers/patreon.ts
@@ -41,6 +41,12 @@ export async function fetchPatreonSponsors(token: string): Promise<Sponsorship[]
     sponsors.push(
       ...sponsorshipData.data
         .filter((pledge: any) => !!pledge.relationships?.reward?.data)
+        .filter((pledge: any) => {
+          // Filter declined users
+          if (pledge.attributes.declined_since)
+            return new Date(pledge.attributes.declined_since).getTime() - new Date().getTime() > 0
+          return true
+        })
         .map((pledge: any) => ({
           pledge,
           patron: sponsorshipData.included.find(


### PR DESCRIPTION
### Description

If a user sponsors use on Patreon and decline payment after a period, the user's avatar will not disappear.

So this PR fixes this issue, filtering sponsors with declined payment and only showing currently active Patreon sponsors.

### Additional context

Reference Patreon API: https://docs.patreon.com/#pledge
