### PR TITLE
fix: always use github link

### DIFF
--- a/src/svg.ts
+++ b/src/svg.ts
@@ -14,7 +14,7 @@ export function generateBadge(
   const size = preset.avatar.size
   const { login } = sponsor
   let name = (sponsor.name || sponsor.login).trim()
-  const url = sponsor.linkUrl || sponsor.login ? `https://github.com/${sponsor.login}` : undefined
+  const url = sponsor.linkUrl || (sponsor.login ? `https://github.com/${sponsor.login}` : undefined)
 
   if (preset.name && preset.name.maxLength && name.length > preset.name.maxLength) {
     if (name.includes(' '))


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fix always use GitHub link

```js
sponsor.linkUrl || sponsor.login ? `https://github.com/${sponsor.login}` : undefined
```

is

```js
(sponsor.linkUrl || sponsor.login) ? `https://github.com/${sponsor.login}` : undefined
```

But we actually want

```
sponsor.linkUrl || (sponsor.login ? `https://github.com/${sponsor.login}` : undefined)
```

### Linked Issues


### Additional context

We can use [`no-mixed-operators`](https://eslint.org/docs/latest/rules/no-mixed-operators#groups) to avoid this situation.

<!-- e.g. is there anything you'd like reviewers to focus on? -->
