### PR TITLE
feat: Add `websiteUrl` for GitHub & OpenCollective

### DIFF
--- a/src/providers/github/index.ts
+++ b/src/providers/github/index.ts
@@ -110,11 +110,13 @@ export function makeQuery(login: string, type: string, cursor?: string) {
             login
             name
             avatarUrl
+            websiteUrl
           }
           ...on User {
             login
             name
             avatarUrl
+            websiteUrl
           }
         }
       }

--- a/src/providers/opencollective.ts
+++ b/src/providers/opencollective.ts
@@ -83,6 +83,7 @@ export async function fetchOpenCollectiveSponsors(key?: string, id?: string, slu
         type: (collective ? v.account.type : v.oppositeAccount.name) === 'INDIVIDUAL' ? 'User' : 'Organization',
         login: slug,
         avatarUrl: collective ? v.account.imageUrl : v.oppositeAccount.imageUrl,
+        websiteUrl: collective ? v.account.website : v.oppositeAccount.website,
         linkUrl: `https://opencollective.com/${slug}`,
       },
       isOneTime: !v.tier || v.tier.type === 'DONATION',
@@ -128,6 +129,7 @@ function makeQuery(id?: string, slug?: string, githubHandle?: string, offset?: n
           name
           slug
           type
+          website
           isIncognito
           imageUrl(height: 460, format: png)
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export interface Sponsor {
   avatarUrlHighRes?: string
   avatarUrlMediumRes?: string
   avatarUrlLowRes?: string
+  websiteUrl?: string
   linkUrl?: string
 }
 


### PR DESCRIPTION
### Description

Adds the `websiteUrl` field from the GitHub and OpenCollective APIs.

### Linked Issues

N/A

### Additional context

I am trying to use sponsorkit to replace [Cheerio's hand-rolled script](https://github.com/cheeriojs/cheerio/blob/20b29983cf937d0ff700cb642cc0453b208e208e/scripts/fetch-sponsors.mts) to fetch sponsors. The `websiteUrl` is required for that, and currently missing.