### PR TITLE
feat: Add `linkUrl` for GitHub Sponsors

### DIFF
--- a/src/providers/github/index.ts
+++ b/src/providers/github/index.ts
@@ -64,6 +64,7 @@ export async function fetchGitHubSponsors(
     .map((raw: any): Sponsorship => ({
       sponsor: {
         ...raw.sponsorEntity,
+        linkUrl: `https://github.com/${raw.sponsorEntity.login}`,
         __typename: undefined,
         type: raw.sponsorEntity.__typename,
       },

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -14,7 +14,7 @@ export function generateBadge(
   const size = preset.avatar.size
   const { login } = sponsor
   let name = (sponsor.name || sponsor.login).trim()
-  const url = sponsor.linkUrl || (sponsor.login ? `https://github.com/${sponsor.login}` : undefined)
+  const url = sponsor.linkUrl
 
   if (preset.name && preset.name.maxLength && name.length > preset.name.maxLength) {
     if (name.includes(' '))


### PR DESCRIPTION
### Description

All other providers supply this, so let's add it for GitHub Sponsors.

### Linked Issues

N/A

### Additional context

N/A
