### PR TITLE
fix(patreon): do not list members who never pledged

### DIFF
--- a/src/providers/patreon.ts
+++ b/src/providers/patreon.ts
@@ -42,7 +42,7 @@ export async function fetchPatreonSponsors(token: string): Promise<Sponsorship[]
       ...sponsorshipData.data
         .filter((membership: any) => {
           // Filter out "declined" and "never pledged" members
-          return membership.attributes.patron_status !== "declined_patron" && membership.attributes.patron_status !== null;
+          return membership.attributes.patron_status !== 'declined_patron' && membership.attributes.patron_status !== null;
         })
         .map((membership: any) => ({
           membership,

--- a/src/providers/patreon.ts
+++ b/src/providers/patreon.ts
@@ -41,8 +41,8 @@ export async function fetchPatreonSponsors(token: string): Promise<Sponsorship[]
     sponsors.push(
       ...sponsorshipData.data
         .filter((membership: any) => {
-          // Filter declined users
-          return membership.attributes.patron_status !== 'declined_patron'
+          // Filter out "declined" and "never pledged" members
+          return membership.attributes.patron_status !== "declined_patron" && membership.attributes.patron_status !== null;
         })
         .map((membership: any) => ({
           membership,


### PR DESCRIPTION
Previously, members who only "followed" the creator profile would be listed as sponsors. This change adds a `null` check to avoid this scenario. 

---

Per [Patreon documentation](https://docs.patreon.com/#member):

- `patron_status`: One of `active_patron`, `declined_patron`, `former_patron`. A `null` value indicates the member has never pledged. Can be `null`.

