### PR TITLE
fix(afdian): read `exechangeRate` from env

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -31,6 +31,7 @@ export function loadEnv(): Partial<SponsorkitConfig> {
     afdian: {
       userId: process.env.SPONSORKIT_AFDIAN_USER_ID || process.env.AFDIAN_USER_ID,
       token: process.env.SPONSORKIT_AFDIAN_TOKEN || process.env.AFDIAN_TOKEN,
+      exechangeRate: Number.parseFloat(process.env.SPONSORKIT_AFDIAN_EXECHANGERATE || process.env.AFDIAN_EXECHANGERATE) || undefined,
     },
     outputDir: process.env.SPONSORKIT_DIR,
   }


### PR DESCRIPTION
### Description

The `exechangeRate` option isn't read by the env resolver, which causes the option cannot be configured by users.

This pr adds the missing `exechangeRate` env reader for afdian provider.