### PR TITLE
feat(afdian): more precise sponsor algorithm

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -32,6 +32,7 @@ export function loadEnv(): Partial<SponsorkitConfig> {
       userId: process.env.SPONSORKIT_AFDIAN_USER_ID || process.env.AFDIAN_USER_ID,
       token: process.env.SPONSORKIT_AFDIAN_TOKEN || process.env.AFDIAN_TOKEN,
       exechangeRate: Number.parseFloat(process.env.SPONSORKIT_AFDIAN_EXECHANGERATE || process.env.AFDIAN_EXECHANGERATE) || undefined,
+      webAuthToken: process.env.SPONSORKIT_AFDIAN_WEB_AUTH_TOKEN || process.env.AFDIAN_WEB_AUTH_TOKEN,
     },
     outputDir: process.env.SPONSORKIT_DIR,
   }

--- a/src/env.ts
+++ b/src/env.ts
@@ -32,6 +32,7 @@ export function loadEnv(): Partial<SponsorkitConfig> {
       userId: process.env.SPONSORKIT_AFDIAN_USER_ID || process.env.AFDIAN_USER_ID,
       token: process.env.SPONSORKIT_AFDIAN_TOKEN || process.env.AFDIAN_TOKEN,
       exechangeRate: Number.parseFloat(process.env.SPONSORKIT_AFDIAN_EXECHANGERATE || process.env.AFDIAN_EXECHANGERATE || '0') || undefined,
+      webAuthToken: process.env.SPONSORKIT_AFDIAN_WEB_AUTH_TOKEN || process.env.AFDIAN_WEB_AUTH_TOKEN,
     },
     outputDir: process.env.SPONSORKIT_DIR,
   }

--- a/src/providers/afdian/get-monthly-orders.ts
+++ b/src/providers/afdian/get-monthly-orders.ts
@@ -44,7 +44,7 @@ export async function fetchAfdianMonthlySponsors(
     orders.push(...ordersData.data.list)
   } while (has_more === 1)
 
-  consola.info(`[sponsorkit] afdian: ${orders.length} orders found`)
+  consola.info(`afdian: ${orders.length} orders found`)
 
   const sponsors: Record<string, {
     plans: {
@@ -94,8 +94,7 @@ export async function fetchAfdianMonthlySponsors(
       // all_sum_amount is based on cny
       monthlyDollars: userData.plans.every((plan: any) => plan.isExpired)
         ? -1
-        // 60 seconds * 60 minutes * 24 hours * 30 days
-        : userData.plans.map(plan => plan.monthlyAmount / exechangeRate).reduce((acc, curr) => acc + curr, 0),
+        : userData.plans.filter(plan => !plan.isExpired).map(plan => plan.monthlyAmount / exechangeRate).reduce((acc, curr) => acc + curr, 0),
       privacyLevel: 'PUBLIC',
       tierName: 'Afdian',
       // ASC

--- a/src/providers/afdian/get-monthly-orders.ts
+++ b/src/providers/afdian/get-monthly-orders.ts
@@ -1,0 +1,113 @@
+import { $fetch } from 'ofetch'
+import { consola } from 'consola'
+import type { SponsorkitConfig, Sponsorship } from '../../types'
+
+export async function fetchAfdianMonthlySponsors(
+  options: SponsorkitConfig['afdian'] = {},
+): Promise<Sponsorship[]> {
+  const { webAuthToken, exechangeRate = 6.5 } = options
+
+  if (!webAuthToken)
+    throw new Error('Afdian web auth_token are required')
+
+  const orders: any[] = []
+  const ordersApi = 'https://afdian.net/api/my/sponsored-bill-filter'
+  let page = 1
+  let has_more
+  do {
+    const ordersData = await $fetch(ordersApi, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'Cookie': `auth_token=${webAuthToken}`,
+      },
+      responseType: 'json',
+      query: {
+        page,
+        sort_field: 'update_time',
+        sort_value: 'desc',
+        is_redeem: '0',
+        plan_id: '',
+        sign_status: '',
+        has_remark: '0',
+        status: '',
+        order_id: '',
+        nick_name: '',
+        remark: '',
+        express_no: '',
+      },
+    })
+    page += 1
+    if (ordersData?.ec !== 200)
+      break
+    has_more = ordersData.data.has_more
+    orders.push(...ordersData.data.list)
+  } while (has_more === 1)
+
+  consola.info(`[sponsorkit] afdian: ${orders.length} orders found`)
+
+  const sponsors: Record<string, {
+    plans: {
+      isOneTime: boolean
+      amount: number
+      month: number
+      monthlyAmount: number
+      beginTime: number
+      endTime: number
+      isExpired: boolean
+    }[]
+    id: string
+    name: string
+    avatar: string
+  }> = {}
+  orders.forEach((order) => {
+    if (!sponsors[order.user.user_id]) {
+      sponsors[order.user.user_id] = {
+        plans: [],
+        id: order.user.user_id,
+        name: order.user.name,
+        avatar: order.user.avatar,
+      }
+    }
+    const isOneTime = Array.isArray(order.plan) && order.plan.length === 0
+
+    sponsors[order.user.user_id].plans.push({
+      isOneTime,
+      amount: Number.parseFloat(order.total_amount),
+      month: order.month,
+      monthlyAmount: Number.parseFloat(order.total_amount) / order.month,
+      beginTime: order.time_range.begin_time,
+      endTime: order.time_range.end_time,
+      isExpired: order.time_range.end_time < Date.now() / 1000,
+    })
+  })
+
+  const processed = Object.entries(sponsors).map(([userId, userData]): Sponsorship => {
+    return {
+      sponsor: {
+        type: 'User',
+        login: userId,
+        name: userData.name,
+        avatarUrl: userData.avatar,
+        linkUrl: `https://afdian.net/u/${userId}`,
+      },
+      // all_sum_amount is based on cny
+      monthlyDollars: userData.plans.every((plan: any) => plan.isExpired)
+        ? -1
+        // 60 seconds * 60 minutes * 24 hours * 30 days
+        : userData.plans.map(plan => plan.monthlyAmount / exechangeRate).reduce((acc, curr) => acc + curr, 0),
+      privacyLevel: 'PUBLIC',
+      tierName: 'Afdian',
+      // ASC
+      createdAt: new Date(userData.plans.map(plan => plan.beginTime).sort((a, b) => a - b)[0] * 1000).toISOString(),
+      // DESC
+      expireAt: new Date(userData.plans.map(plan => plan.beginTime).sort((a, b) => b - a)[0] * 1000).toISOString(),
+      // empty string means no plan, consider as one time sponsor
+      isOneTime: userData.plans.every((plan: any) => plan.isOneTime),
+      provider: 'afdian',
+      raw: userData,
+    }
+  })
+
+  return processed
+}

--- a/src/providers/afdian/index.ts
+++ b/src/providers/afdian/index.ts
@@ -1,13 +1,14 @@
 import { createHash } from 'node:crypto'
 import { $fetch } from 'ofetch'
-import type { Provider, SponsorkitConfig, Sponsorship } from '../types'
+import type { Provider, SponsorkitConfig, Sponsorship } from '../../types'
+import { fetchAfdianMonthlySponsors } from './get-monthly-orders'
 
 // afdian api docs https://afdian.net/p/9c65d9cc617011ed81c352540025c377
 
 export const AfdianProvider: Provider = {
   name: 'afdian',
   fetchSponsors(config) {
-    return fetchAfdianSponsors(config.afdian)
+    return config.afdian?.webAuthToken ? fetchAfdianMonthlySponsors(config.afdian) : fetchAfdianSponsors(config.afdian)
   },
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,6 +147,14 @@ export interface ProvidersConfig {
      * @default 6.5
      */
     exechangeRate?: number
+    /**
+     * Afdian Web Token got from document.cookie.
+     *
+     * Will read from `SPONSORKIT_AFDIAN_TOKEN` environment variable if not set.
+     *
+     * @deprecated It's not recommended set this value directly, pass from env or use `.env` file.
+     */
+    webAuthToken?: string
   }
 }
 


### PR DESCRIPTION
### Description

There're some edge cases that afdian's open api doesn't cover. When a sponsor choose a lower priced subscription with longer time, the sum usually reached the next subscription price. At this situation, they will be displayed as the next level subscriber while get a longer time of display due to afdian open api doesn't return the amount creator actually get from subscription.

For example, the price of level 1 sub is $5, and for level 2 sub is $10, subscribing level 1 for 2 months can be displayed as a level 2 subscriber and can be displayed for 2 months while directly subscribing level 2 sub costs the same amount but can only be displayed for 1 month.

This pr is going to implement a algorithm directly calculate the monthly income by getting orders data from afdian web api, which requires the `auth_token` in cookies.