### PR TITLE
fix(opencollective): adds comprehensive queries and support for past OC sponsors

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -117,7 +117,7 @@ export interface TierPartition {
   sponsors: Sponsorship[]
 }
 
-export function partitionTiers(sponsors: Sponsorship[], tiers: Tier[]) {
+export function partitionTiers(sponsors: Sponsorship[], tiers: Tier[], includePastSponsors?: boolean) {
   const tierMappings = tiers!.map<TierPartition>(tier => ({
     monthlyDollars: tier.monthlyDollars ?? 0,
     tier,
@@ -133,6 +133,7 @@ export function partitionTiers(sponsors: Sponsorship[], tiers: Tier[]) {
 
   sponsors
     .sort((a, b) => Date.parse(a.createdAt!) - Date.parse(b.createdAt!))
+    .filter(s => s.monthlyDollars > 0 || includePastSponsors) // Past sponsors monthlyDollars is -1
     .forEach((sponsor) => {
       const tier = tierMappings.find(t => sponsor.monthlyDollars >= t.monthlyDollars) ?? tierMappings[0]
       tier.sponsors.push(sponsor)

--- a/src/providers/opencollective.ts
+++ b/src/providers/opencollective.ts
@@ -1,5 +1,5 @@
 import { $fetch } from 'ofetch'
-import type { Provider, Sponsorship } from '../types'
+import type { Provider, SocialLink, Sponsorship } from '../types'
 
 export const OpenCollectiveProvider: Provider = {
   name: 'opencollective',
@@ -9,7 +9,7 @@ export const OpenCollectiveProvider: Provider = {
       config.opencollective?.id,
       config.opencollective?.slug,
       config.opencollective?.githubHandle,
-      config.opencollective?.type,
+      config.includePastSponsors,
     )
   },
 }
@@ -17,22 +17,20 @@ export const OpenCollectiveProvider: Provider = {
 const API = 'https://api.opencollective.com/graphql/v2/'
 const graphql = String.raw
 
-export async function fetchOpenCollectiveSponsors(key?: string, id?: string, slug?: string, githubHandle?: string, type?: string): Promise<Sponsorship[]> {
+export async function fetchOpenCollectiveSponsors(key?: string, id?: string, slug?: string, githubHandle?: string,
+  includePastSponsors?: boolean): Promise<Sponsorship[]> {
   if (!key)
     throw new Error('OpenCollective api key is required')
   if (!slug && !id && !githubHandle)
     throw new Error('OpenCollective collective id or slug or GitHub handle is required')
 
-  let collective = true
-  if (type && type !== 'collective')
-    collective = false
-
   const sponsors: any[] = []
+  const monthlyTransactions: any[] = []
   let offset
   offset = 0
 
   do {
-    const query = makeQuery(id, slug, githubHandle, offset, collective)
+    const query = makeSubscriptionsQuery(id, slug, githubHandle, offset, !includePastSponsors)
     const data = await $fetch(API, {
       method: 'POST',
       body: { query },
@@ -41,100 +39,316 @@ export async function fetchOpenCollectiveSponsors(key?: string, id?: string, slu
         'Content-Type': 'application/json',
       },
     }) as any
-
-    const nodes = collective
-      ? data.data.collective?.members.nodes
-      : data.data.account?.transactions.nodes
+    const nodes = data.data.account.orders.nodes
+    const totalCount = data.data.account.orders.totalCount
 
     sponsors.push(...(nodes || []))
-    if ((nodes.length) !== 0)
-      offset += nodes.length
-    else
-      offset = undefined
+
+    if ((nodes.length) !== 0) {
+      if (totalCount > offset + nodes.length)
+        offset += nodes.length
+      else
+        offset = undefined
+    }
+    else { offset = undefined }
   } while (offset)
 
-  const count: any = []
-  const processed: Sponsorship[] = []
-
-  for (const i in sponsors
-    .sort((a, b) => (new Date(b.createdAt).getDate() - new Date(a.createdAt).getDate()))
-  ) {
-    const v = sponsors[i]
-    const slug: string = collective ? v.account.slug : v.oppositeAccount.slug
-
-    if (!collective) {
-      if (slug in count) {
-        delete processed![count[slug].index]
-
-        count[slug].valueInCents += v.amount.valueInCents
-        count[slug].index = i
-      }
-      else {
-        count[slug] = {
-          index: i,
-          valueInCents: v.amount.valueInCents,
-        }
-      }
-    }
-
-    processed!.push({
-      sponsor: {
-        name: collective ? v.account.name : v.oppositeAccount.name,
-        type: (collective ? v.account.type : v.oppositeAccount.name) === 'INDIVIDUAL' ? 'User' : 'Organization',
-        login: slug,
-        avatarUrl: collective ? v.account.imageUrl : v.oppositeAccount.imageUrl,
-        websiteUrl: collective ? v.account.website : v.oppositeAccount.website,
-        linkUrl: `https://opencollective.com/${slug}`,
+  offset = 0
+  do {
+    const now: Date = new Date()
+    const dateFrom: Date | undefined = includePastSponsors ? undefined : new Date(now.getFullYear(), now.getMonth(), 1)
+    const query = makeTransactionsQuery(id, slug, githubHandle, offset, dateFrom)
+    const data = await $fetch(API, {
+      method: 'POST',
+      body: { query },
+      headers: {
+        'Api-Key': `${key}`,
+        'Content-Type': 'application/json',
       },
-      isOneTime: !v.tier || v.tier.type === 'DONATION',
-      monthlyDollars: (collective
-        ? (v.tier ? v.tier.amount.valueInCents : v.totalDonations.valueInCents)
-        : count[slug].valueInCents
-      ) / 100,
-      privacyLevel: (collective ? v.account.isIncognito : v.oppositeAccount.isIncognito) ? 'PRIVATE' : 'PUBLIC',
-      tierName: collective ? (!v.tier ? '' : v.tier.name) : undefined,
-      createdAt: v.createdAt,
-    })
-  }
+    }) as any
+    const nodes = data.data.account.transactions.nodes
+    const totalCount = data.data.account.transactions.totalCount
 
-  return processed.filter(i => i !== null)
+    monthlyTransactions.push(...(nodes || []))
+    if ((nodes.length) !== 0) {
+      if (totalCount > offset + nodes.length)
+        offset += nodes.length
+      else
+        offset = undefined
+    }
+    else { offset = undefined }
+  } while (offset)
+
+  const sponsorships: [string, Sponsorship][] = sponsors
+    .map(createSponsorFromOrder)
+    .filter((sponsorship): sponsorship is [string, Sponsorship] => sponsorship !== null)
+
+  const monthlySponsorships: [string, Sponsorship][] = monthlyTransactions
+    .map(t => createSponsorFromTransaction(t, sponsorships.map(i => i[1].raw.id)))
+    .filter((sponsorship): sponsorship is [string, Sponsorship] => sponsorship !== null && sponsorship !== undefined)
+
+  const transactionsBySponsorId: Map<string, Sponsorship> = monthlySponsorships.reduce((map, [id, sponsor]) => {
+    const existingSponsor = map.get(id)
+    if (existingSponsor) {
+      const createdAt = new Date(sponsor.createdAt!)
+      const existingSponsorCreatedAt = new Date(existingSponsor.createdAt!)
+      if (createdAt >= existingSponsorCreatedAt)
+        map.set(id, sponsor)
+
+      else if (new Date(existingSponsorCreatedAt.getFullYear(), existingSponsorCreatedAt.getMonth(), 1) === new Date(createdAt.getFullYear(), createdAt.getMonth(), 1))
+        existingSponsor.monthlyDollars += sponsor.monthlyDollars
+    }
+    else { map.set(id, sponsor) }
+
+    return map
+  }, new Map())
+
+  const processed: Map<string, Sponsorship> = sponsorships
+    .reduce((map, [id, sponsor]) => {
+      const existingSponsor = map.get(id)
+      if (existingSponsor) {
+        const createdAt = new Date(sponsor.createdAt!)
+        const existingSponsorCreatedAt = new Date(existingSponsor.createdAt!)
+        if (createdAt >= existingSponsorCreatedAt)
+          map.set(id, sponsor)
+      }
+      else { map.set(id, sponsor) }
+      return map
+    }, new Map())
+
+  const result: Sponsorship[] = Array.from(processed.values()).concat(Array.from(transactionsBySponsorId.values()))
+  return result
 }
 
-function makeQuery(id?: string, slug?: string, githubHandle?: string, offset?: number, collective = true) {
+function createSponsorFromOrder(order: any): [string, Sponsorship] | undefined {
+  const slug = order.fromAccount.slug
+  if (slug === 'github-sponsors') // ignore github sponsors
+    return undefined
+
+  let monthlyDollars: number = order.amount.value
+  if (order.status !== 'ACTIVE')
+    monthlyDollars = -1
+
+  else if (order.frequency === 'MONTHLY')
+    monthlyDollars = order.amount.value
+
+  else if (order.frequency === 'YEARLY')
+    monthlyDollars = order.amount.value / 12
+
+  else if (order.frequency === 'ONETIME')
+    monthlyDollars = order.amount.value
+
+  const sponsor: Sponsorship = {
+    sponsor: {
+      name: order.fromAccount.name,
+      type: getAccountType(order.fromAccount.type),
+      login: slug,
+      avatarUrl: order.fromAccount.imageUrl,
+      websiteUrl: getBestUrl(order.fromAccount.socialLinks),
+      linkUrl: `https://opencollective.com/${slug}`,
+    },
+    isOneTime: order.frequency === 'ONETIME',
+    monthlyDollars,
+    privacyLevel: order.fromAccount.isIncognito ? 'PRIVATE' : 'PUBLIC',
+    tierName: order.tier?.name,
+    createdAt: order.frequency === 'ONETIME' ? order.createdAt : order.order?.createdAt,
+    raw: order,
+  }
+
+  return [order.fromAccount.id, sponsor]
+}
+
+function createSponsorFromTransaction(transaction: any, excludeOrders: string[]): [string, Sponsorship] | undefined {
+  const slug = transaction.fromAccount.slug
+  if (slug === 'github-sponsors') // ignore github sponsors
+    return undefined
+
+  if (excludeOrders.includes(transaction.order?.id))
+    return undefined
+
+  let monthlyDollars: number = transaction.amount.value
+  if (transaction.order?.status !== 'ACTIVE') {
+    const firsrDayOfCurrentMonth = new Date(new Date().getUTCFullYear(), new Date().getUTCMonth(), 1)
+    if (new Date(transaction.createdAt) < firsrDayOfCurrentMonth)
+      monthlyDollars = -1
+  }
+  else if (transaction.order?.frequency === 'MONTHLY') {
+    monthlyDollars = transaction.order?.amount.value
+  }
+  else if (transaction.order?.frequency === 'YEARLY') {
+    monthlyDollars = transaction.order?.amount.value / 12
+  }
+
+  const sponsor: Sponsorship = {
+    sponsor: {
+      name: transaction.fromAccount.name,
+      type: getAccountType(transaction.fromAccount.type),
+      login: slug,
+      avatarUrl: transaction.fromAccount.imageUrl,
+      websiteUrl: getBestUrl(transaction.fromAccount.socialLinks),
+      linkUrl: `https://opencollective.com/${slug}`,
+    },
+    isOneTime: transaction.order?.frequency === 'ONETIME',
+    monthlyDollars,
+    privacyLevel: transaction.fromAccount.isIncognito ? 'PRIVATE' : 'PUBLIC',
+    tierName: transaction.tier?.name,
+    createdAt: transaction.order?.frequency === 'ONETIME' ? transaction.createdAt : transaction.order?.createdAt,
+    raw: transaction,
+  }
+
+  return [transaction.fromAccount.id, sponsor]
+}
+
+/**
+ * Make a partial query for the OpenCollective API.
+ * This is used to query for either a collective or an account.
+ * If `id` is set, it will query for a collective.
+ * If `slug` is set, it will query for an account.
+ * If `githubHandle` is set, it will query for an account.
+ * If none of the above are set, an error will be thrown.
+ *
+ * @param id Collective id
+ * @param slug Collective slug
+ * @param githubHandle GitHub handle
+ * @returns The partial query
+ * @see makeQuery
+ * @see fetchOpenCollectiveSponsors
+ */
+function makeAccountQueryPartial(id?: string, slug?: string, githubHandle?: string) {
+  if (id)
+    return `id: "${id}"`
+  else if (slug)
+    return `slug: "${slug}"`
+  else if (githubHandle)
+    return `githubHandle: "${githubHandle}"`
+  else
+    throw new Error('OpenCollective collective id or slug or GitHub handle is required')
+}
+
+function makeTransactionsQuery(id?: string, slug?: string, githubHandle?: string, offset?: number, dateFrom?: Date, dateTo?: Date) {
+  const accountQueryPartial = makeAccountQueryPartial(id, slug, githubHandle)
+  const dateFromParam = dateFrom ? `, dateFrom: "${dateFrom.toISOString()}"` : ''
+  const dateToParam = dateTo ? `, dateTo: "${dateTo.toISOString()}"` : ''
   return graphql`{
-  ${collective ? 'collective' : 'account'}(${id ? `id: "${id}", ` : ''}${slug ? `slug: "${slug}", ` : ''}${githubHandle ? `githubHandle: "${githubHandle}", ` : ''}throwIfMissing: true) {
-    ${collective ? 'members' : 'transactions'}(limit: 100${offset ? ` offset: ${offset}` : ''}${collective ? ' role: [BACKER]' : ''}) {
-      offset
-      limit
-      totalCount
-      nodes {
-        id
-        createdAt
-        ${collective
-    ? `
-        role
-        tier {
-          name
+    account(${accountQueryPartial}) {
+      transactions(limit: 1000, offset:${offset}, type: CREDIT ${dateFromParam} ${dateToParam}) {
+        offset
+        limit
+        totalCount
+        nodes {
           type
-          amount {
-            valueInCents
+          kind
+          id
+          order {
+            id
+            status
+            frequency
+            tier {
+              name
+            }
+            amount {
+              value
+            }
           }
-        }`
-: ''
-        }
-        ${collective ? 'totalDonations' : 'amount'} {
-          valueInCents
-        }
-        ${collective ? 'account' : 'oppositeAccount'} {
-          name
-          slug
-          type
-          website
-          isIncognito
-          imageUrl(height: 460, format: png)
+          createdAt
+          amount {
+            value
+          }
+          fromAccount {
+            name
+            id
+            slug
+            type
+            socialLinks {
+              url
+              type
+            }
+            isIncognito
+            imageUrl(height: 460, format: png)
+          }
         }
       }
     }
+  }`
+}
+
+function makeSubscriptionsQuery(id?: string, slug?: string, githubHandle?: string, offset?: number, activeOnly?: boolean) {
+  const activeOrNot = activeOnly ? 'onlyActiveSubscriptions: true' : 'onlySubscriptions: true'
+  return graphql`{
+    account(${makeAccountQueryPartial(id, slug, githubHandle)}) {
+      orders(limit: 1000, offset:${offset}, ${activeOrNot}, filter: INCOMING) {
+        nodes {
+          id
+          createdAt
+          frequency
+          status
+          tier {
+            name
+          }
+          amount {
+            value
+          }
+          totalDonations {
+            value
+          }
+          createdAt
+          fromAccount {
+            name
+            id
+            slug
+            type
+            socialLinks {
+              url
+              type
+            }
+            isIncognito
+            imageUrl(height: 460, format: png)
+          }
+        }
+      }
+    }
+  }`
+}
+
+/**
+ * Get the account type from the API values.
+ *
+ * @param type The type of the account from the API
+ * @returns The account type
+ */
+function getAccountType(type: string): 'User' | 'Organization' {
+  switch (type) {
+    case 'INDIVIDUAL':
+      return 'User'
+    case 'ORGANIZATION':
+    case 'COLLECTIVE':
+    case 'FUND':
+    case 'PROJECT':
+    case 'EVENT':
+    case 'VENDOR':
+    case 'BOT':
+      return 'Organization'
+    default:
+      throw new Error(`Unknown account type: ${type}`)
   }
-}`
+}
+
+/**
+ * Get the best URL from a list of social links.
+ * The best URL is the first URL in a priority order,
+ * with WEBSITE being the highest priority.
+ * The rest of the order is somewhat arbitrary.
+ *
+ * @param socialLinks List of social links
+ * @returns The best URL or `undefined` if no URL is found
+ * @see makeQuery
+ */
+function getBestUrl(socialLinks: SocialLink[]): string | undefined {
+  const urls = socialLinks
+    .filter(i => i.type === 'WEBSITE' || i.type === 'GITHUB' || i.type === 'GITLAB' || i.type === 'TWITTER'
+      || i.type === 'FACEBOOK' || i.type === 'YOUTUBE' || i.type === 'INSTAGRAM'
+      || i.type === 'LINKEDIN' || i.type === 'DISCORD' || i.type === 'TUMBLR')
+    .map(i => i.url)
+
+  return urls[0]
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
This PR is meant to address the issues in #57. 
In addition to that, this PR also adds the ability to query past sponsors for OpenCollective.

I changed the way the OC queries work. Now it follows this process:
- Query all (active) subscriptions (OC `orders`) on an account
  - If the config is set to `includePastSponsors`, query the past sponsors
- Query all transactions on the account (for current month); the transactions include one-time donations
  - Remove any transactions which have an order ID that matches a subscription
  - If the config is set to `includePastSponsors`, query all transactions

These changes allow the code to support monthly sponsors which have subscriptions and also one-time donations. On OpenCollective, it is feasible that a sponsor might do a one-time donation repeatedly, but that donation not be a recurring subscription.

#### Additionally
- I removed the logic around whether the account is a `collective` or not, as it is not relevant because all accounts have `orders` and `transactions`.
- I increased the limit on queries from `100` :arrow_right: `1000`.
  - On accounts that have a lot of orders/transactions, 100 at a time will easily cause a `429 Too Many Requests` error
- I added support for `YEARLY` subscriptions for OC
  - I just divide the amount by 12 to fit it in the `monthlyDollars` field

### Linked Issues
- #57

### Additional context
I have tested this code with the `capawesome` collective, other larger collectives as well (webpack, darkreader, vue, etc), and individual accounts like `kecrily`.

There is potential for some flows to be disrupted by these changes, particularly the individual accounts. They may need to adjust their config, perhaps adding `includePastSponsors`, for example. 

In the case of `kecrily`, the previous code for OC would fetch all transactions on their account without regard to time, so it did already include past sponsors, but that was not necessarily intentional. Now that I have added support for the config option, it is necessary to use that if you want all the past transactions.

#### Related idea
I did not add support for this, but I wonder if anyone might find it useful to have a mode of operation where when listing past sponsors, they are shown according to their *total* donations. Currently, the past sponsors are marked as `-$1`. But I have seen some projects that show their past sponsors' total amount donated. 

By way of example, let's imagine a large one-time donation to a project. That project might want to permanently display that sponsor as a top sponsor.

I have some code that I was working on for this feature, but I am not including it in this PR. If it sounds interesting, I can open another feature request issue for it to be discussed.