### PR TITLE
fix: pass `config.includePastSponsors` to `partitionTiers`

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -88,7 +88,7 @@ export async function run(inlineConfig?: SponsorkitConfig, t = consola) {
 }
 
 export async function defaultComposer(composer: SvgComposer, sponsors: Sponsorship[], config: SponsorkitConfig) {
-  const tierPartitions = partitionTiers(sponsors, config.tiers!)
+  const tierPartitions = partitionTiers(sponsors, config.tiers!, config.includePastSponsors)
 
   composer.addSpan(config.padding?.top ?? 20)
 


### PR DESCRIPTION
### Description

[v0.9.0](https://github.com/antfu/sponsorkit/releases/tag/v0.9.0) did not show GitHub's Past Sponsors.

https://github.com/antfu/sponsorkit/pull/58 introduce `includePastSponsors` argument for `partitionTiers` function, but It looks like that forgot to pass `config.includePastSponsors`.

As a result, past sponsors always to be hidden.

https://github.com/antfu/sponsorkit/blob/35f29eca827894b6f9e89d99bcf5b70bed358ec4/src/config.ts#L120-L136

### Linked Issues

None

### Additional context

Run `npm run build` in `example/` with following env.

```
SPONSORKIT_GITHUB_TOKEN=xxx
SPONSORKIT_GITHUB_LOGIN=azu
```

This example includes [past sponsors](https://github.com/antfu/sponsorkit/blob/35f29eca827894b6f9e89d99bcf5b70bed358ec4/example/sponsor.config.ts).

In v0.9.0:

![sponsors](https://github.com/antfu/sponsorkit/assets/19714/12e232b0-e41b-4acb-864a-97a5ad90f6f7)

In this PR:

![sponsors](https://github.com/antfu/sponsorkit/assets/19714/4771889c-889a-4bee-824d-ed64ec06f5fc)

