### PR TITLE
refactor: replace `fs-extra`

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   "dependencies": {
     "consola": "^3.2.3",
     "dotenv": "^16.3.1",
-    "fs-extra": "^11.2.0",
     "image-data-uri": "^2.0.1",
     "node-html-parser": "^6.1.11",
     "ofetch": "^1.3.3",
@@ -61,7 +60,6 @@
     "@antfu/eslint-config": "^2.4.6",
     "@antfu/ni": "^0.21.12",
     "@antfu/utils": "^0.7.7",
-    "@types/fs-extra": "^11.0.4",
     "@types/node": "^20.10.4",
     "@types/yargs": "^17.0.32",
     "bumpp": "^9.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       dotenv:
         specifier: ^16.3.1
         version: 16.3.1
-      fs-extra:
-        specifier: ^11.2.0
-        version: 11.2.0
       image-data-uri:
         specifier: ^2.0.1
         version: 2.0.1
@@ -48,9 +45,6 @@ importers:
       '@antfu/utils':
         specifier: ^0.7.7
         version: 0.7.7
-      '@types/fs-extra':
-        specifier: ^11.0.4
-        version: 11.0.4
       '@types/node':
         specifier: ^20.10.4
         version: 20.10.4
@@ -1409,21 +1403,8 @@ packages:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
     dev: true
 
-  /@types/fs-extra@11.0.4:
-    resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
-    dependencies:
-      '@types/jsonfile': 6.1.1
-      '@types/node': 20.10.4
-    dev: true
-
   /@types/json-schema@7.0.12:
     resolution: {integrity: sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==}
-    dev: true
-
-  /@types/jsonfile@6.1.1:
-    resolution: {integrity: sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==}
-    dependencies:
-      '@types/node': 20.10.4
     dev: true
 
   /@types/mdast@3.0.10:
@@ -2983,6 +2964,7 @@ packages:
       graceful-fs: 4.2.10
       jsonfile: 6.1.0
       universalify: 2.0.0
+    dev: true
 
   /fs-minipass@2.1.0:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
@@ -3497,6 +3479,7 @@ packages:
       universalify: 2.0.0
     optionalDependencies:
       graceful-fs: 4.2.10
+    dev: true
 
   /jsprim@1.4.2:
     resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
@@ -4727,6 +4710,7 @@ packages:
   /universalify@2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
+    dev: true
 
   /unpack-string@0.0.2:
     resolution: {integrity: sha512-2ZFjp5aY7QwHE6HAp47RnKYfvgAQ5+NwbKq/ZVtty85RDb3/UaTeCfizo5L/fXzM7UkMP/zDtbV+kGW/iJiK6w==}

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,6 +1,7 @@
 import { dirname, join, relative, resolve } from 'node:path'
 import process from 'node:process'
-import fs from 'fs-extra'
+import fs from 'node:fs'
+import fsp from 'node:fs/promises'
 import { consola } from 'consola'
 import c from 'picocolors'
 import { version } from '../package.json'
@@ -39,11 +40,11 @@ export async function run(inlineConfig?: SponsorkitConfig, t = consola) {
     await resolveAvatars(allSponsors, config.fallbackAvatar, t)
     t.success('Avatars resolved')
 
-    await fs.ensureDir(dirname(cacheFile))
-    await fs.writeJSON(cacheFile, allSponsors, { spaces: 2 })
+    await fsp.mkdir(dirname(cacheFile), { recursive: true })
+    await fsp.writeFile(cacheFile, JSON.stringify(allSponsors, null, 2))
   }
   else {
-    allSponsors = await fs.readJSON(cacheFile)
+    allSponsors = JSON.parse(await fsp.readFile(cacheFile, 'utf-8'))
     t.success(`Loaded from cache ${r(cacheFile)}`)
   }
 
@@ -54,10 +55,10 @@ export async function run(inlineConfig?: SponsorkitConfig, t = consola) {
     || (b.sponsor.login || b.sponsor.name).localeCompare(a.sponsor.login || a.sponsor.name), // ASC name
   )
 
-  await fs.ensureDir(dir)
+  await fsp.mkdir(dir, { recursive: true })
   if (config.formats?.includes('json')) {
     const path = join(dir, `${config.name}.json`)
-    await fs.writeJSON(path, allSponsors, { spaces: 2 })
+    await fsp.writeFile(cacheFile, JSON.stringify(allSponsors, null, 2))
     t.success(`Wrote to ${r(path)}`)
   }
 
@@ -76,13 +77,13 @@ export async function run(inlineConfig?: SponsorkitConfig, t = consola) {
 
   if (config.formats?.includes('svg')) {
     const path = join(dir, `${config.name}.svg`)
-    await fs.writeFile(path, svg, 'utf-8')
+    await fsp.writeFile(path, svg, 'utf-8')
     t.success(`Wrote to ${r(path)}`)
   }
 
   if (config.formats?.includes('png')) {
     const path = join(dir, `${config.name}.png`)
-    await fs.writeFile(path, await svgToPng(svg))
+    await fsp.writeFile(path, await svgToPng(svg))
     t.success(`Wrote to ${r(path)}`)
   }
 }


### PR DESCRIPTION
### Description

It is 2024 already, the Node.js built-in fs method has evolved and the `fs-extra` is no longer necessary.

### Linked Issues

N/A

### Additional context

N/A