### PR TITLE
docs: default width on jsdoc

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -200,7 +200,7 @@ export interface SponsorkitRenderOptions {
   /**
    * Width of the image.
    *
-   * @default 700
+   * @default 800
    */
   width?: number
 


### PR DESCRIPTION
https://github.com/antfu-collective/sponsorkit/blob/7bebd4dc71fc5d45290f14bf339bc6484f766e13/src/configs/defaults.ts#L48