### PR TITLE
feat: add Polar.sh provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Supports:
 - [**Patreon**](https://www.patreon.com/)
 - [**OpenCollective**](https://opencollective.com/)
 - [**Afdian**](https://afdian.net/)
+- [**Polar**](https://polar.sh/)
 
 ## Usage
 
@@ -43,6 +44,10 @@ SPONSORKIT_OPENCOLLECTIVE_TYPE=
 SPONSORKIT_AFDIAN_USER_ID=
 ; Create token at https://afdian.net/dashboard/dev
 SPONSORKIT_AFDIAN_TOKEN=
+
+; Polar provider.
+; Get your token at https://polar.sh/settings
+SPONSORKIT_POLAR_TOKEN=
 ```
 
 > Only one provider is required to be configured.
@@ -75,6 +80,9 @@ export default defineConfig({
     // ...
   },
   afdian: {
+    // ...
+  },
+  polar: {
     // ...
   },
 

--- a/src/configs/env.ts
+++ b/src/configs/env.ts
@@ -33,6 +33,9 @@ export function loadEnv(): Partial<SponsorkitConfig> {
       token: process.env.SPONSORKIT_AFDIAN_TOKEN || process.env.AFDIAN_TOKEN,
       exechangeRate: Number.parseFloat(process.env.SPONSORKIT_AFDIAN_EXECHANGERATE || process.env.AFDIAN_EXECHANGERATE || '0') || undefined,
     },
+    polar: {
+      token: process.env.SPONSORKIT_POLAR_TOKEN || process.env.POLAR_TOKEN,
+    },
     outputDir: process.env.SPONSORKIT_DIR,
   }
 

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -3,6 +3,7 @@ import { GitHubProvider } from './github'
 import { PatreonProvider } from './patreon'
 import { OpenCollectiveProvider } from './opencollective'
 import { AfdianProvider } from './afdian'
+import { PolarProvider } from './polar'
 
 export * from './github'
 
@@ -11,6 +12,7 @@ export const ProvidersMap = {
   patreon: PatreonProvider,
   opencollective: OpenCollectiveProvider,
   afdian: AfdianProvider,
+  polar: PolarProvider,
 }
 
 export function guessProviders(config: SponsorkitConfig) {
@@ -26,6 +28,9 @@ export function guessProviders(config: SponsorkitConfig) {
 
   if (config.afdian && config.afdian.userId && config.afdian.token)
     items.push('afdian')
+
+  if (config.polar && config.polar.token)
+    items.push('polar')
 
   // fallback
   if (!items.length)

--- a/src/providers/polar.ts
+++ b/src/providers/polar.ts
@@ -35,7 +35,6 @@ export async function fetchPolarSponsors(token: string): Promise<Sponsorship[]> 
   return subscriptions
     /**
      * - People can subscribe for free on Polar : the price is null in this case
-     * - We also only keep `active` subscriptions. Still not sure what `inactive` means
      */
     .filter(sub => !!sub.price)
     .map((sub) => {

--- a/src/providers/polar.ts
+++ b/src/providers/polar.ts
@@ -1,0 +1,54 @@
+import { ofetch } from 'ofetch'
+import type { Provider, Sponsorship } from '../types'
+
+export const PolarProvider: Provider = {
+  name: 'polar',
+  fetchSponsors(config) {
+    return fetchPolarSponsors(config.polar?.token || config.token!)
+  },
+}
+
+export async function fetchPolarSponsors(token: string): Promise<Sponsorship[]> {
+  if (!token)
+    throw new Error('Polar token is required')
+
+  const apiFetch = ofetch.create({
+    baseURL: 'https://api.polar.sh/api/v1',
+    headers: { Authorization: `Bearer ${token}` },
+  })
+
+  /**
+   * First fetch the list of all subscriptions. This is a paginated
+   * endpoint so loop through all the pages
+   */
+  let page = 1
+  let pages = 1
+  const subscriptions = []
+  do {
+    const subs = await apiFetch('/subscriptions/subscriptions/search', { params: { page } })
+    subscriptions.push(...subs.items)
+
+    pages = subs.pagination.max_page
+    page += 1
+  } while (page <= pages)
+
+  /**
+   * People can subscribe for free on Polar : the price is null in this case
+   * so we filter out those subscriptions
+   */
+  return subscriptions.filter(sub => !!sub.price)
+    .map(sub => ({
+      sponsor: {
+        name: sub.user.public_name,
+        avatarUrl: sub.user.avatar_url,
+        login: sub.user.github_username,
+        type: sub.subscription_tier.type === 'individual' ? 'User' : 'Organization',
+      },
+      isOneTime: false,
+      provider: 'polar',
+      privacyLevel: 'PUBLIC',
+      createdAt: new Date(sub.created_at).toISOString(),
+      tierName: sub.subscription_tier.name,
+      monthlyDollars: sub.price.price_amount / 100,
+    }))
+}

--- a/src/providers/polar.ts
+++ b/src/providers/polar.ts
@@ -37,19 +37,23 @@ export async function fetchPolarSponsors(token: string): Promise<Sponsorship[]> 
      * - People can subscribe for free on Polar : the price is null in this case
      * - We also only keep `active` subscriptions. Still not sure what `inactive` means
      */
-    .filter(sub => !!sub.price && sub.status === 'active')
-    .map(sub => ({
-      sponsor: {
-        name: sub.user.public_name,
-        avatarUrl: sub.user.avatar_url,
-        login: sub.user.github_username,
-        type: sub.subscription_tier.type === 'individual' ? 'User' : 'Organization',
-      },
-      isOneTime: false,
-      provider: 'polar',
-      privacyLevel: 'PUBLIC',
-      createdAt: new Date(sub.created_at).toISOString(),
-      tierName: sub.subscription_tier.name,
-      monthlyDollars: sub.price.price_amount / 100,
-    }))
+    .filter(sub => !!sub.price)
+    .map((sub) => {
+      const isActive = sub.status === 'active'
+
+      return {
+        sponsor: {
+          name: sub.user.public_name,
+          avatarUrl: sub.user.avatar_url,
+          login: sub.user.github_username,
+          type: sub.subscription_tier.type === 'individual' ? 'User' : 'Organization',
+        },
+        isOneTime: false,
+        provider: 'polar',
+        privacyLevel: 'PUBLIC',
+        createdAt: new Date(sub.created_at).toISOString(),
+        tierName: isActive ? sub.subscription_tier.name : undefined,
+        monthlyDollars: isActive ? sub.sub.price.price_amount / 100 : -1,
+      }
+    })
 }

--- a/src/providers/polar.ts
+++ b/src/providers/polar.ts
@@ -32,11 +32,12 @@ export async function fetchPolarSponsors(token: string): Promise<Sponsorship[]> 
     page += 1
   } while (page <= pages)
 
-  /**
-   * People can subscribe for free on Polar : the price is null in this case
-   * so we filter out those subscriptions
-   */
-  return subscriptions.filter(sub => !!sub.price)
+  return subscriptions
+    /**
+     * - People can subscribe for free on Polar : the price is null in this case
+     * - We also only keep `active` subscriptions. Still not sure what `inactive` means
+     */
+    .filter(sub => !!sub.price && sub.status === 'active')
     .map(sub => ({
       sponsor: {
         name: sub.user.public_name,

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,6 +161,9 @@ export interface ProvidersConfig {
      * Polar token that have access to your sponsorships.
      *
      * Will read from `SPONSORKIT_POLAR_TOKEN` environment variable if not set.
+     *
+     * @see https://polar.sh/settings
+     * @deprecated It's not recommended set this value directly, pass from env or use `.env` file.
      */
     token?: string
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,7 +60,7 @@ export interface Sponsorship {
 
 export type OutputFormat = 'svg' | 'png' | 'json'
 
-export type ProviderName = 'github' | 'patreon' | 'opencollective' | 'afdian'
+export type ProviderName = 'github' | 'patreon' | 'opencollective' | 'afdian' | 'polar'
 
 export interface ProvidersConfig {
   github?: {
@@ -154,6 +154,15 @@ export interface ProvidersConfig {
      * @default 6.5
      */
     exechangeRate?: number
+  }
+
+  polar?: {
+    /**
+     * Polar token that have access to your sponsorships.
+     *
+     * Will read from `SPONSORKIT_POLAR_TOKEN` environment variable if not set.
+     */
+    token?: string
   }
 }
 


### PR DESCRIPTION
### Description

Add [Polar](https://polar.sh/) as provider.

### Linked Issues

Close #65 

### Additional context

There's some information I don't have right now because i am new to Polar.sh. For example : I'm not sure what the `status` of a subscriptions means. Does an `inactive` status mean that the person is a past sponsor? 

I'll soon have answers to these questions, when some people will unsubscribe from my Polar. And I will do a new PR to update the code if there's anything wrong with our implementation. In the meantime, we're just keeping the `active` subscriptions and those with a defined `price`. and it seems to working fine