### PR TITLE
fix(polar): `Cannot read properties of undefined (reading 'price')`

### DIFF
--- a/src/providers/polar.ts
+++ b/src/providers/polar.ts
@@ -55,7 +55,7 @@ export async function fetchPolarSponsors(token: string): Promise<Sponsorship[]> 
         privacyLevel: 'PUBLIC',
         createdAt: new Date(sub.created_at).toISOString(),
         tierName: isActive ? sub.subscription_tier.name : undefined,
-        monthlyDollars: isActive ? sub.subscription.price.price_amount / 100 : -1,
+        monthlyDollars: isActive ? sub.price.price_amount / 100 : -1,
       }
     })
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The following error message appears when I retrieve sponsorships from Polar (see [this run](https://github.com/capawesome-team/static/actions/runs/9043587892/job/24851395184)): 

```
[info] Fetching sponsorships from polar...
TypeError: Cannot read properties of undefined (reading 'price')
    at file:///home/runner/work/static/static/node_modules/sponsorkit/dist/shared/sponsorkit.d376c786.mjs:1047:51
    at Array.map (<anonymous>)
    at fetchPolarSponsors (file:///home/runner/work/static/static/node_modules/sponsorkit/dist/shared/sponsorkit.d376c786.mjs:1030:53)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async run (file:///home/runner/work/static/static/node_modules/sponsorkit/dist/cli.mjs:143:22)
    at async Object.handler (file:///home/runner/work/static/static/node_modules/sponsorkit/dist/cli.mjs:367:5)
Error: Process completed with exit code 1.
```

According to the [API documentation](https://api.polar.sh/redoc#tag/subscriptions/operation/subscriptions:search_subscriptions), there is no `subscription` property in the response. Instead, the `price` property is at the top level.

### Linked Issues

There was already a fix recently (see #67), but it doesn't seem to have helped. @Julien-R44 Have you tested your changes? Is it currently working for you?

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
