### PR TITLE
fix(polar): `Cannot read properties of undefined (reading 'type')`

### DIFF
--- a/src/providers/polar.ts
+++ b/src/providers/polar.ts
@@ -51,7 +51,7 @@ export async function fetchPolarSponsors(token: string, organization?: string): 
           name: sub.user.public_name,
           avatarUrl: sub.user.avatar_url,
           login: sub.user.github_username,
-          type: sub.subscription_tier.type === 'individual' ? 'User' : 'Organization',
+          type: sub.product.type === 'individual' ? 'User' : 'Organization',
           socialLogins: {
             github: sub.user.github_username,
           },
@@ -60,7 +60,7 @@ export async function fetchPolarSponsors(token: string, organization?: string): 
         provider: 'polar',
         privacyLevel: 'PUBLIC',
         createdAt: new Date(sub.created_at).toISOString(),
-        tierName: isActive ? sub.subscription_tier.name : undefined,
+        tierName: isActive ? sub.product.name : undefined,
         monthlyDollars: isActive ? sub.price.price_amount / 100 : -1,
       }
     })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The following error message appears when I retrieve sponsorships from Polar (see [this run](https://github.com/capawesome-team/static/actions/runs/9115823123/job/25063023476)): 

```
[info] Fetching sponsorships from polar...
TypeError: Cannot read properties of undefined (reading 'type')
    at file:///home/runner/work/static/static/node_modules/sponsorkit/dist/shared/sponsorkit.ccaa557f.mjs:1055:37
    at Array.map (<anonymous>)
    at fetchPolarSponsors (file:///home/runner/work/static/static/node_modules/sponsorkit/dist/shared/sponsorkit.ccaa557f.mjs:1048:53)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async run (file:///home/runner/work/static/static/node_modules/sponsorkit/dist/cli.mjs:143:22)
    at async Object.handler (file:///home/runner/work/static/static/node_modules/sponsorkit/dist/cli.mjs:367:5)
Error: Process completed with exit code 1.
```

It seems like `subscription_tier` was an internal property which has just been removed. This is the API documentation: https://api.polar.sh/redoc#tag/subscriptions/operation/subscriptions:search_subscriptions

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
