### PR TITLE
docs: use `tierPresets` in README instead of `presets`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ npx sponsorkit
 Create `sponsorkit.config.js` file with:
 
 ```ts
-import { defineConfig, presets } from 'sponsorkit'
+import { defineConfig, tierPresets } from 'sponsorkit'
 
 export default defineConfig({
   // Providers configs
@@ -98,27 +98,27 @@ export default defineConfig({
     {
       title: 'Past Sponsors',
       monthlyDollars: -1,
-      preset: presets.xs,
+      preset: tierPresets.xs,
     },
     // Default tier
     {
       title: 'Backers',
-      preset: presets.base,
+      preset: tierPresets.base,
     },
     {
       title: 'Sponsors',
       monthlyDollars: 10,
-      preset: presets.medium,
+      preset: tierPresets.medium,
     },
     {
       title: 'Silver Sponsors',
       monthlyDollars: 50,
-      preset: presets.large,
+      preset: tierPresets.large,
     },
     {
       title: 'Gold Sponsors',
       monthlyDollars: 100,
-      preset: presets.xl,
+      preset: tierPresets.xl,
     },
   ],
 })


### PR DESCRIPTION
### Description

This PR suggests updating the README to directly use `tierPresets` instead of the deprecated `presets`.

It has been introduced via https://github.com/antfu-collective/sponsorkit/commit/8341489925a004d9e0fc117672a8ed9d5665c4db.

When starting from scratch from the README, users will probably start configuring their project with the `sponsorkit.config.js` provided in this same README. The idea would be here to provide directly the non-deprecated version.

If the deprecated version was kept in the README voluntarily on your side, feel free to close directly this PR :)

### Linked Issues

N/A

### Additional context

`tierPresets` has been introduced in https://github.com/antfu-collective/sponsorkit/commit/8341489925a004d9e0fc117672a8ed9d5665c4db.
