### PR TITLE
fix(polar): Implement updates to Polar API

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ SPONSORKIT_AFDIAN_TOKEN=
 ; Get your token at https://polar.sh/settings
 SPONSORKIT_POLAR_TOKEN=
 ; The name of the organization to fetch sponsorships from.
-; If not set, it will fetch the sponsorships of the user.
 SPONSORKIT_POLAR_ORGANIZATION=
 ```
 

--- a/src/providers/polar.ts
+++ b/src/providers/polar.ts
@@ -15,7 +15,7 @@ export async function fetchPolarSponsors(token: string, organization?: string): 
     throw new Error('Polar organization is required')
 
   const apiFetch = ofetch.create({
-    baseURL: 'https://api.polar.sh/api/v1',
+    baseURL: 'https://api.polar.sh/v1',
     headers: { Authorization: `Bearer ${token}` },
   })
 

--- a/src/providers/polar.ts
+++ b/src/providers/polar.ts
@@ -11,6 +11,8 @@ export const PolarProvider: Provider = {
 export async function fetchPolarSponsors(token: string, organization?: string): Promise<Sponsorship[]> {
   if (!token)
     throw new Error('Polar token is required')
+  if (!organization)
+    throw new Error('Polar organization is required')
 
   const apiFetch = ofetch.create({
     baseURL: 'https://api.polar.sh/api/v1',
@@ -18,20 +20,34 @@ export async function fetchPolarSponsors(token: string, organization?: string): 
   })
 
   /**
-   * First fetch the list of all subscriptions. This is a paginated
+   * Get the organization by config name. Fetching the ID for future API calls.
+   *
+   * For backward compatability with existing configs, improved readability & DX,
+   * we keep config.polar.organization vs. introducing config.polar.organization_id even
+   * though we only need the ID.
+   */
+  const org = await apiFetch('/organizations', {
+    params: {
+      name: organization,
+    },
+  })
+  const orgId = org.items?.[0]?.id
+  if (!orgId)
+    throw new Error(`Polar organization "${organization}" not found`)
+
+  /**
+   * Fetch the list of all subscriptions. This is a paginated
    * endpoint so loop through all the pages
    */
   let page = 1
   let pages = 1
   const subscriptions = []
   do {
-    const params: Record<string, any> = { page }
-    if (organization) {
-      params.organization_name = organization
-      // Polar only supports GitHub for now
-      params.platform = 'github'
+    const params: Record<string, any> = {
+      organization_id: orgId,
+      page,
     }
-    const subs = await apiFetch('/subscriptions/subscriptions/search', { params })
+    const subs = await apiFetch('/subscriptions', { params })
     subscriptions.push(...subs.items)
 
     pages = subs.pagination.max_page


### PR DESCRIPTION
### Description

Birk from Polar here 👋🏼 We're in the process of updating our API to reach a stable and fully documented v1.0. Unfortunately, we've had to introduce some breaking changes in that process. Causing `sponsorkit` to no longer work with Polar in the current version. Caused by:

- `sponsorkit` using our deprecated `/subscriptions/subscriptions/search` endpoint vs. `/subscriptions`

This PR fixes the above and makes `sponsorkit` work with Polar again. However, I also took the opportunity to ensure the implementation is more accurate & uses our 1.0 endpoints to be more future proof. Below are the changes in full:

- Updated base URL to `https://api.polar.sh/v1/(.*)` from legacy `https://api.polar.sh/api/v1/(.*)`
- Require `SPONSORKIT_POLAR_ORGANIZATION` in `.env` if using Polar (see more context below)
- Fetch the requested organization from `/organizations` to respect the same `sponsorkit` implementation API, but going against our updated API endpoints vs. passing an organization name to subscriptions directly (no longer supported)

**Breaking change to sponsorkit**
`SPONSORKIT_POLAR_ORGANIZATION` is now required and will throw in error if not present, but Polar is used. The former implementation stated we default to the users organization if not present. That was not the case nor is it supported now. We require an organization to be fetched and an explicit organization ID to be used in filtering `/subscriptions`

So we need to require it here. However, I don't suspect any active `sponsorkit` user would be impacted since using it with Polar now is broken & specifically an empty `SPONSORKIT_POLAR_ORGANIZATION` would not have defaulted to the users personal one - it needs to be explicit.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
