### PR TITLE
fix(polar): Use new `slug` filter vs. deprecated `name`

### DIFF
--- a/src/providers/polar.ts
+++ b/src/providers/polar.ts
@@ -28,7 +28,7 @@ export async function fetchPolarSponsors(token: string, organization?: string): 
    */
   const org = await apiFetch('/organizations', {
     params: {
-      name: organization,
+      slug: organization,
     },
   })
   const orgId = org.items?.[0]?.id


### PR DESCRIPTION
### Description

Well this is embarrassing and I apologies for the extra work @antfu 😔 We've done a big refactor of organizations (no longer coupled 1:1 with GitHub) within Polar. Along with it, we've made a subtle change to the API and filtering them by `slug` vs. `name`. This PR updates the integration accordingly.

Sorry, I hope and expect we won't make any more changes here at least within 2024 :)

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
