### PR TITLE
fix: missing Patreon declined users as previous sponsors

### DIFF
--- a/src/providers/patreon.ts
+++ b/src/providers/patreon.ts
@@ -40,10 +40,8 @@ export async function fetchPatreonSponsors(token: string): Promise<Sponsorship[]
     })
     sponsors.push(
       ...sponsorshipData.data
-        .filter((membership: any) => {
-          // Filter out "declined" and "never pledged" members
-          return membership.attributes.patron_status !== 'declined_patron' && membership.attributes.patron_status !== null
-        })
+        // Filter out "never pledged" members
+        .filter((membership: any) => membership.attributes.patron_status !== null)
         .map((membership: any) => ({
           membership,
           patron: sponsorshipData.included.find(
@@ -64,7 +62,8 @@ export async function fetchPatreonSponsors(token: string): Promise<Sponsorship[]
         linkUrl: raw.patron.attributes.url,
       },
       isOneTime: false, // One-time pledges not supported
-      monthlyDollars: raw.membership.attributes.patron_status === 'former_patron' ? -1 : Math.floor(raw.membership.attributes.currently_entitled_amount_cents / 100),
+      // The "former_patron" and "declined_patron" both is past sponsors
+      monthlyDollars: ['former_patron', 'declined_patron'].includes(raw.membership.attributes.patron_status) ? -1 : Math.floor(raw.membership.attributes.currently_entitled_amount_cents / 100),
       privacyLevel: 'PUBLIC', // Patreon is all public
       tierName: 'Patreon',
       createdAt: raw.membership.attributes.pledge_relationship_start,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

If a user sponsors use on Patreon and decline payment after a period, the user's avatar will not show in past sponsors.

I think the `former_patron` and `declined_patron` status both is past sponsors, so this PR will be fixed.

### Linked Issues

### Additional context

Reference Patreon API: https://docs.patreon.com/#member

<!-- e.g. is there anything you'd like reviewers to focus on? -->
