### PR TITLE
perf: reduce cache size (1/4)

### DIFF
--- a/src/processing/image.ts
+++ b/src/processing/image.ts
@@ -18,7 +18,7 @@ export async function resolveAvatars(
     return undefined
   })()
 
-  const fallbackDataUri = fallbackAvatar && pngToDataUri(await round(fallbackAvatar, 0.5, 100))
+  const fallbackDataUri = fallbackAvatar && (await round(fallbackAvatar, 0.5, 100)).toString('base64')
 
   const pLimit = await import('p-limit').then(r => r.default)
   const limit = pLimit(15)
@@ -58,9 +58,9 @@ export async function resolveAvatars(
       const highResBase64 = highRes.toString('base64')
 
       ship.sponsor.avatarBuffer = highResBase64
-      ship.sponsor.avatarUrlHighRes = `data:image/png;base64,${highResBase64}`
-      ship.sponsor.avatarUrlMediumRes = pngToDataUri(mediumRes)
-      ship.sponsor.avatarUrlLowRes = pngToDataUri(lowRes)
+      ship.sponsor.avatarUrlHighRes = highResBase64
+      ship.sponsor.avatarUrlMediumRes = mediumRes.toString('base64')
+      ship.sponsor.avatarUrlLowRes = lowRes.toString('base64')
     }
   })))
 }
@@ -113,8 +113,4 @@ export function svgToPng(svg: string) {
   return sharp(Buffer.from(svg), { density: 150 })
     .png({ quality: 90 })
     .toBuffer()
-}
-
-export function pngToDataUri(png: Buffer) {
-  return `data:image/png;base64,${png.toString('base64')}`
 }

--- a/src/processing/image.ts
+++ b/src/processing/image.ts
@@ -55,8 +55,10 @@ export async function resolveAvatars(
         round(data, radius, 50),
       ])
 
-      ship.sponsor.avatarBuffer = highRes.toString('base64')
-      ship.sponsor.avatarUrlHighRes = pngToDataUri(highRes)
+      const highResBase64 = highRes.toString('base64')
+
+      ship.sponsor.avatarBuffer = highResBase64
+      ship.sponsor.avatarUrlHighRes = `data:image/png;base64,${highResBase64}`
       ship.sponsor.avatarUrlMediumRes = pngToDataUri(mediumRes)
       ship.sponsor.avatarUrlLowRes = pngToDataUri(lowRes)
     }

--- a/src/processing/image.ts
+++ b/src/processing/image.ts
@@ -10,9 +10,11 @@ export async function resolveAvatars(
   getFallbackAvatar: SponsorkitConfig['fallbackAvatar'],
   t = consola,
 ) {
-  const fallbackAvatar = await (() => {
-    if (typeof getFallbackAvatar === 'string')
-      return $fetch(getFallbackAvatar, { responseType: 'arrayBuffer' })
+  const fallbackAvatar = await (async () => {
+    if (typeof getFallbackAvatar === 'string') {
+      const data = await $fetch(getFallbackAvatar, { responseType: 'arrayBuffer' })
+      return Buffer.from(data)
+    }
     if (getFallbackAvatar)
       return getFallbackAvatar
     return undefined
@@ -24,7 +26,7 @@ export async function resolveAvatars(
   const limit = pLimit(15)
 
   return Promise.all(ships.map(ship => limit(async () => {
-    const data = (ship.privacyLevel === 'PRIVATE' || !ship.sponsor.avatarUrl)
+    const pngArrayBuffer = (ship.privacyLevel === 'PRIVATE' || !ship.sponsor.avatarUrl)
       ? fallbackAvatar
       : await $fetch(ship.sponsor.avatarUrl, {
         responseType: 'arrayBuffer',
@@ -43,16 +45,17 @@ export async function resolveAvatars(
     if (ship.privacyLevel === 'PRIVATE' && fallbackDataUri)
       ship.sponsor.avatarUrl = fallbackDataUri
 
-    if (data) {
+    if (pngArrayBuffer) {
+      const pngBuffer = Buffer.from(pngArrayBuffer)
       const radius = ship.sponsor.type === 'Organization' ? 0.1 : 0.5
       const [
         highRes,
         mediumRes,
         lowRes,
       ] = await Promise.all([
-        round(data, radius, 120),
-        round(data, radius, 80),
-        round(data, radius, 50),
+        round(pngBuffer, radius, 120),
+        round(pngBuffer, radius, 80),
+        round(pngBuffer, radius, 50),
       ])
 
       const highResBase64 = highRes.toString('base64')
@@ -65,40 +68,12 @@ export async function resolveAvatars(
   })))
 }
 
-function toBuffer(ab: ArrayBuffer) {
-  const buf = Buffer.alloc(ab.byteLength)
-  const view = new Uint8Array(ab)
-  for (let i = 0; i < buf.length; ++i)
-    buf[i] = view[i]
-
-  return buf
-}
-
-export function base64ToArrayBuffer(base64: string) {
-  const binaryString = atob(base64)
-  const len = binaryString.length
-  const bytes = new Uint8Array(len)
-  for (let i = 0; i < len; i++)
-    bytes[i] = binaryString.charCodeAt(i)
-
-  return bytes.buffer
-}
-
-export function arrayBufferToBase64(buffer: ArrayBuffer) {
-  let binary = ''
-  const bytes = new Uint8Array(buffer)
-  const len = bytes.byteLength
-  for (let i = 0; i < len; i++)
-    binary += String.fromCharCode(bytes[i])
-  return btoa(binary)
-}
-
-export async function round(image: string | ArrayBuffer, radius = 0.5, size = 100) {
+export async function round(image: Buffer, radius = 0.5, size = 100) {
   const rect = Buffer.from(
     `<svg><rect x="0" y="0" width="${size}" height="${size}" rx="${size * radius}" ry="${size * radius}"/></svg>`,
   )
 
-  return await sharp(typeof image === 'string' ? image : toBuffer(image))
+  return await sharp(image)
     .resize(size, size, { fit: sharp.fit.cover })
     .composite([{
       blend: 'dest-in',

--- a/src/processing/image.ts
+++ b/src/processing/image.ts
@@ -45,10 +45,20 @@ export async function resolveAvatars(
 
     if (data) {
       const radius = ship.sponsor.type === 'Organization' ? 0.1 : 0.5
-      ship.sponsor.avatarBuffer = arrayBufferToBase64(data)
-      ship.sponsor.avatarUrlHighRes = pngToDataUri(await round(data, radius, 120))
-      ship.sponsor.avatarUrlMediumRes = pngToDataUri(await round(data, radius, 80))
-      ship.sponsor.avatarUrlLowRes = pngToDataUri(await round(data, radius, 50))
+      const [
+        highRes,
+        mediumRes,
+        lowRes,
+      ] = await Promise.all([
+        round(data, radius, 120),
+        round(data, radius, 80),
+        round(data, radius, 50),
+      ])
+
+      ship.sponsor.avatarBuffer = highRes.toString('base64')
+      ship.sponsor.avatarUrlHighRes = pngToDataUri(highRes)
+      ship.sponsor.avatarUrlMediumRes = pngToDataUri(mediumRes)
+      ship.sponsor.avatarUrlLowRes = pngToDataUri(lowRes)
     }
   })))
 }

--- a/src/processing/svg.ts
+++ b/src/processing/svg.ts
@@ -1,7 +1,9 @@
 import type { BadgePreset, Sponsor, SponsorkitRenderOptions, Sponsorship } from '../types'
 
-export function genSvgImage(x: number, y: number, size: number, url: string) {
-  return `<image x="${x}" y="${y}" width="${size}" height="${size}" href="${url}"/>`
+const dataImagePngBase64 = `data:image/png;base64,`
+
+export function genSvgImage(x: number, y: number, size: number, base64Image: string) {
+  return `<image x="${x}" y="${y}" width="${size}" height="${size}" href="${dataImagePngBase64}${base64Image}"/>`
 }
 
 export function generateBadge(

--- a/src/renders/circles.ts
+++ b/src/renders/circles.ts
@@ -1,4 +1,4 @@
-import { base64ToArrayBuffer, pngToDataUri, round } from '../processing/image'
+import { base64ToArrayBuffer, round } from '../processing/image'
 import { generateBadge, SvgComposer } from '../processing/svg'
 import type { Sponsor, SponsorkitRenderer, Sponsorship } from '../types'
 
@@ -80,8 +80,8 @@ async function getRoundedAvatars(sponsor: Sponsor) {
   /// keep-sorted
   return {
     ...sponsor,
-    avatarUrlHighRes: pngToDataUri(highRes),
-    avatarUrlLowRes: pngToDataUri(mediumRes),
-    avatarUrlMediumRes: pngToDataUri(lowRes),
+    avatarUrlHighRes: highRes.toString('base64'),
+    avatarUrlLowRes: mediumRes.toString('base64'),
+    avatarUrlMediumRes: lowRes.toString('base64'),
   }
 }

--- a/src/renders/circles.ts
+++ b/src/renders/circles.ts
@@ -67,11 +67,21 @@ async function getRoundedAvatars(sponsor: Sponsor) {
     return sponsor
 
   const data = base64ToArrayBuffer(sponsor.avatarBuffer)
+  const [
+    highRes,
+    mediumRes,
+    lowRes,
+  ] = await Promise.all([
+    round(data, 0.5, 120),
+    round(data, 0.5, 80),
+    round(data, 0.5, 50),
+  ])
+
   /// keep-sorted
   return {
     ...sponsor,
-    avatarUrlHighRes: pngToDataUri(await round(data, 0.5, 120)),
-    avatarUrlLowRes: pngToDataUri(await round(data, 0.5, 50)),
-    avatarUrlMediumRes: pngToDataUri(await round(data, 0.5, 80)),
+    avatarUrlHighRes: pngToDataUri(highRes),
+    avatarUrlLowRes: pngToDataUri(mediumRes),
+    avatarUrlMediumRes: pngToDataUri(lowRes),
   }
 }

--- a/src/renders/circles.ts
+++ b/src/renders/circles.ts
@@ -1,4 +1,5 @@
-import { base64ToArrayBuffer, round } from '../processing/image'
+import { Buffer } from 'node:buffer'
+import { round } from '../processing/image'
 import { generateBadge, SvgComposer } from '../processing/svg'
 import type { Sponsor, SponsorkitRenderer, Sponsorship } from '../types'
 
@@ -66,7 +67,7 @@ async function getRoundedAvatars(sponsor: Sponsor) {
   if (!sponsor.avatarBuffer || sponsor.type === 'User')
     return sponsor
 
-  const data = base64ToArrayBuffer(sponsor.avatarBuffer)
+  const data = Buffer.from(sponsor.avatarBuffer, 'base64')
   const [
     highRes,
     mediumRes,

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,7 +72,9 @@ export interface Sponsorship {
   raw?: any
 }
 
-export type OutputFormat = 'svg' | 'png' | 'json'
+export const outputFormats = ['svg', 'png', 'json'] as const
+
+export type OutputFormat = typeof outputFormats[number]
 
 export type ProviderName = 'github' | 'patreon' | 'opencollective' | 'afdian' | 'polar'
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
- Store images as the highest resolution we use, instead of the original quality. This probably has the biggest gains
- Always use Buffers instead of ArrayBuffers. This allows us to remove any utils for converting ArrayBuffers to Base64.
- Parallelize sharp processing avatar PNGs
- Parallelize writing output formats

#### Results
- Old cache size: `9.6 MB`
- New cache size: `2.6 MB`

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
- I took out the perf improvements from https://github.com/antfu-collective/sponsorkit/pull/90
- I'll follow up with a WebP PR