### PR TITLE
perf: remove avatar sizes from cache (3/4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ export default defineConfig({
   // Rendering configs
   width: 800,
   renderer: 'tiers', // or 'circles'
-  formats: ['json', 'svg', 'png'],
+  formats: ['json', 'svg', 'png', 'webp'],
   tiers: [
     // Past sponsors, currently only supports GitHub
     {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,24 @@
+import { Buffer } from 'node:buffer'
+import type { Sponsorship } from './types'
+
+export function stringifyCache(cache: Sponsorship[]): string {
+  return JSON.stringify(
+    cache,
+    (_key, value) => {
+      if (value && value.type === 'Buffer' && Array.isArray(value.data)) {
+        return Buffer.from(value.data).toString('base64')
+      }
+      return value
+    },
+    2,
+  )
+}
+
+export function parseCache(cache: string): Sponsorship[] {
+  return JSON.parse(cache, (key, value) => {
+    if (key === 'avatarBuffer') {
+      return Buffer.from(value, 'base64')
+    }
+    return value
+  })
+}

--- a/src/processing/image.ts
+++ b/src/processing/image.ts
@@ -18,7 +18,7 @@ export async function resolveAvatars(
     return undefined
   })()
 
-  const fallbackDataUri = fallbackAvatar && pngToDataUri(await round(fallbackAvatar, 0.5, 100))
+  const fallbackDataUri = fallbackAvatar && (await round(fallbackAvatar, 0.5, 100)).toString('base64')
 
   const pLimit = await import('p-limit').then(r => r.default)
   const limit = pLimit(15)
@@ -58,9 +58,9 @@ export async function resolveAvatars(
       const highResBase64 = highRes.toString('base64')
 
       ship.sponsor.avatarBuffer = highResBase64
-      ship.sponsor.avatarUrlHighRes = `data:image/png;base64,${highResBase64}`
-      ship.sponsor.avatarUrlMediumRes = pngToDataUri(mediumRes)
-      ship.sponsor.avatarUrlLowRes = pngToDataUri(lowRes)
+      ship.sponsor.avatarUrlHighRes = highResBase64
+      ship.sponsor.avatarUrlMediumRes = mediumRes.toString('base64')
+      ship.sponsor.avatarUrlLowRes = lowRes.toString('base64')
     }
   })))
 }
@@ -113,8 +113,4 @@ export function svgToPng(svg: string) {
   return sharp(Buffer.from(svg), { density: 150 })
     .png({ quality: 90 })
     .toBuffer()
-}
-
-export function pngToDataUri(png: Buffer) {
-  return `data:image/png;base64,${png.toString('base64')}`
 }

--- a/src/processing/image.ts
+++ b/src/processing/image.ts
@@ -5,65 +5,51 @@ import sharp from 'sharp'
 import { version } from '../../package.json'
 import type { SponsorkitConfig, Sponsorship } from '../types'
 
+async function fetchImage(url: string) {
+  const arrayBuffer = await $fetch(url, {
+    responseType: 'arrayBuffer',
+    headers: {
+      'User-Agent': `Mozilla/5.0 Chrome/124.0.0.0 Safari/537.36 Sponsorkit/${version}`,
+    },
+  })
+  return Buffer.from(arrayBuffer)
+}
+
 export async function resolveAvatars(
   ships: Sponsorship[],
   getFallbackAvatar: SponsorkitConfig['fallbackAvatar'],
   t = consola,
 ) {
-  const fallbackAvatar = await (async () => {
+  const fallbackAvatar = await (() => {
     if (typeof getFallbackAvatar === 'string') {
-      const data = await $fetch(getFallbackAvatar, { responseType: 'arrayBuffer' })
-      return Buffer.from(data)
+      return fetchImage(getFallbackAvatar)
     }
     if (getFallbackAvatar)
       return getFallbackAvatar
-    return undefined
   })()
-
-  const fallbackDataUri = fallbackAvatar && (await round(fallbackAvatar, 0.5, 100)).toString('base64')
 
   const pLimit = await import('p-limit').then(r => r.default)
   const limit = pLimit(15)
 
   return Promise.all(ships.map(ship => limit(async () => {
-    const pngArrayBuffer = (ship.privacyLevel === 'PRIVATE' || !ship.sponsor.avatarUrl)
-      ? fallbackAvatar
-      : await $fetch(ship.sponsor.avatarUrl, {
-        responseType: 'arrayBuffer',
-        headers: {
-          'User-Agent': `Mozilla/5.0 Chrome/124.0.0.0 Safari/537.36 Sponsorkit/${version}`,
-        },
-      })
-        .catch((e) => {
-          t.error(`Failed to fetch avatar for ${ship.sponsor.login || ship.sponsor.name} [${ship.sponsor.avatarUrl}]`)
-          t.error(e)
-          if (fallbackAvatar)
-            return fallbackAvatar
-          throw e
-        })
+    if (ship.privacyLevel === 'PRIVATE' || !ship.sponsor.avatarUrl) {
+      ship.sponsor.avatarBuffer = fallbackAvatar
+      return
+    }
 
-    if (ship.privacyLevel === 'PRIVATE' && fallbackDataUri)
-      ship.sponsor.avatarUrl = fallbackDataUri
+    const pngBuffer = await fetchImage(ship.sponsor.avatarUrl).catch((e) => {
+      t.error(`Failed to fetch avatar for ${ship.sponsor.login || ship.sponsor.name} [${ship.sponsor.avatarUrl}]`)
+      t.error(e)
+      if (fallbackAvatar)
+        return fallbackAvatar
+      throw e
+    })
 
-    if (pngArrayBuffer) {
-      const pngBuffer = Buffer.from(pngArrayBuffer)
+    if (pngBuffer) {
       const radius = ship.sponsor.type === 'Organization' ? 0.1 : 0.5
-      const [
-        highRes,
-        mediumRes,
-        lowRes,
-      ] = await Promise.all([
-        round(pngBuffer, radius, 120),
-        round(pngBuffer, radius, 80),
-        round(pngBuffer, radius, 50),
-      ])
 
-      const highResBase64 = highRes.toString('base64')
-
-      ship.sponsor.avatarBuffer = highResBase64
-      ship.sponsor.avatarUrlHighRes = highResBase64
-      ship.sponsor.avatarUrlMediumRes = mediumRes.toString('base64')
-      ship.sponsor.avatarUrlLowRes = lowRes.toString('base64')
+      // Store the highest resolution version we use of the original image
+      ship.sponsor.avatarBuffer = await round(pngBuffer, radius, 120)
     }
   })))
 }

--- a/src/processing/image.ts
+++ b/src/processing/image.ts
@@ -55,8 +55,10 @@ export async function resolveAvatars(
         round(data, radius, 50),
       ])
 
-      ship.sponsor.avatarBuffer = highRes.toString('base64')
-      ship.sponsor.avatarUrlHighRes = pngToDataUri(highRes)
+      const highResBase64 = highRes.toString('base64')
+
+      ship.sponsor.avatarBuffer = highResBase64
+      ship.sponsor.avatarUrlHighRes = `data:image/png;base64,${highResBase64}`
       ship.sponsor.avatarUrlMediumRes = pngToDataUri(mediumRes)
       ship.sponsor.avatarUrlLowRes = pngToDataUri(lowRes)
     }

--- a/src/processing/image.ts
+++ b/src/processing/image.ts
@@ -10,9 +10,11 @@ export async function resolveAvatars(
   getFallbackAvatar: SponsorkitConfig['fallbackAvatar'],
   t = consola,
 ) {
-  const fallbackAvatar = await (() => {
-    if (typeof getFallbackAvatar === 'string')
-      return $fetch(getFallbackAvatar, { responseType: 'arrayBuffer' })
+  const fallbackAvatar = await (async () => {
+    if (typeof getFallbackAvatar === 'string') {
+      const data = await $fetch(getFallbackAvatar, { responseType: 'arrayBuffer' })
+      return Buffer.from(data)
+    }
     if (getFallbackAvatar)
       return getFallbackAvatar
     return undefined
@@ -24,7 +26,7 @@ export async function resolveAvatars(
   const limit = pLimit(15)
 
   return Promise.all(ships.map(ship => limit(async () => {
-    const data = (ship.privacyLevel === 'PRIVATE' || !ship.sponsor.avatarUrl)
+    const pngArrayBuffer = (ship.privacyLevel === 'PRIVATE' || !ship.sponsor.avatarUrl)
       ? fallbackAvatar
       : await $fetch(ship.sponsor.avatarUrl, {
         responseType: 'arrayBuffer',
@@ -43,16 +45,17 @@ export async function resolveAvatars(
     if (ship.privacyLevel === 'PRIVATE' && fallbackDataUri)
       ship.sponsor.avatarUrl = fallbackDataUri
 
-    if (data) {
+    if (pngArrayBuffer) {
+      const pngBuffer = Buffer.from(pngArrayBuffer)
       const radius = ship.sponsor.type === 'Organization' ? 0.1 : 0.5
       const [
         highRes,
         mediumRes,
         lowRes,
       ] = await Promise.all([
-        round(data, radius, 120),
-        round(data, radius, 80),
-        round(data, radius, 50),
+        round(pngBuffer, radius, 120),
+        round(pngBuffer, radius, 80),
+        round(pngBuffer, radius, 50),
       ])
 
       const highResBase64 = highRes.toString('base64')
@@ -65,40 +68,12 @@ export async function resolveAvatars(
   })))
 }
 
-function toBuffer(ab: ArrayBuffer) {
-  const buf = Buffer.alloc(ab.byteLength)
-  const view = new Uint8Array(ab)
-  for (let i = 0; i < buf.length; ++i)
-    buf[i] = view[i]
-
-  return buf
-}
-
-export function base64ToArrayBuffer(base64: string) {
-  const binaryString = atob(base64)
-  const len = binaryString.length
-  const bytes = new Uint8Array(len)
-  for (let i = 0; i < len; i++)
-    bytes[i] = binaryString.charCodeAt(i)
-
-  return bytes.buffer
-}
-
-export function arrayBufferToBase64(buffer: ArrayBuffer) {
-  let binary = ''
-  const bytes = new Uint8Array(buffer)
-  const len = bytes.byteLength
-  for (let i = 0; i < len; i++)
-    binary += String.fromCharCode(bytes[i])
-  return btoa(binary)
-}
-
-export async function round(image: string | ArrayBuffer, radius = 0.5, size = 100) {
+export async function round(image: Buffer, radius = 0.5, size = 100) {
   const rect = Buffer.from(
     `<svg><rect x="0" y="0" width="${size}" height="${size}" rx="${size * radius}" ry="${size * radius}"/></svg>`,
   )
 
-  return await sharp(typeof image === 'string' ? image : toBuffer(image))
+  return await sharp(image)
     .resize(size, size, { fit: sharp.fit.cover })
     .composite([{
       blend: 'dest-in',

--- a/src/processing/image.ts
+++ b/src/processing/image.ts
@@ -89,3 +89,9 @@ export function svgToPng(svg: string) {
     .png({ quality: 90 })
     .toBuffer()
 }
+
+export function svgToWebp(svg: string) {
+  return sharp(Buffer.from(svg), { density: 150 })
+    .webp()
+    .toBuffer()
+}

--- a/src/processing/image.ts
+++ b/src/processing/image.ts
@@ -45,10 +45,20 @@ export async function resolveAvatars(
 
     if (data) {
       const radius = ship.sponsor.type === 'Organization' ? 0.1 : 0.5
-      ship.sponsor.avatarBuffer = arrayBufferToBase64(data)
-      ship.sponsor.avatarUrlHighRes = pngToDataUri(await round(data, radius, 120))
-      ship.sponsor.avatarUrlMediumRes = pngToDataUri(await round(data, radius, 80))
-      ship.sponsor.avatarUrlLowRes = pngToDataUri(await round(data, radius, 50))
+      const [
+        highRes,
+        mediumRes,
+        lowRes,
+      ] = await Promise.all([
+        round(data, radius, 120),
+        round(data, radius, 80),
+        round(data, radius, 50),
+      ])
+
+      ship.sponsor.avatarBuffer = highRes.toString('base64')
+      ship.sponsor.avatarUrlHighRes = pngToDataUri(highRes)
+      ship.sponsor.avatarUrlMediumRes = pngToDataUri(mediumRes)
+      ship.sponsor.avatarUrlLowRes = pngToDataUri(lowRes)
     }
   })))
 }

--- a/src/processing/svg.ts
+++ b/src/processing/svg.ts
@@ -1,7 +1,9 @@
 import type { BadgePreset, Sponsor, SponsorkitRenderOptions, Sponsorship } from '../types'
 
-export function genSvgImage(x: number, y: number, size: number, url: string) {
-  return `<image x="${x}" y="${y}" width="${size}" height="${size}" href="${url}"/>`
+const dataImagePngBase64 = `data:image/png;base64,`
+
+export function genSvgImage(x: number, y: number, size: number, base64Image: string) {
+  return `<image x="${x}" y="${y}" width="${size}" height="${size}" href="${dataImagePngBase64}${base64Image}"/>`
 }
 
 export function generateBadge(

--- a/src/renders/circles.ts
+++ b/src/renders/circles.ts
@@ -1,4 +1,4 @@
-import { base64ToArrayBuffer, pngToDataUri, round } from '../processing/image'
+import { base64ToArrayBuffer, round } from '../processing/image'
 import { generateBadge, SvgComposer } from '../processing/svg'
 import type { Sponsor, SponsorkitRenderer, Sponsorship } from '../types'
 
@@ -80,8 +80,8 @@ async function getRoundedAvatars(sponsor: Sponsor) {
   /// keep-sorted
   return {
     ...sponsor,
-    avatarUrlHighRes: pngToDataUri(highRes),
-    avatarUrlLowRes: pngToDataUri(mediumRes),
-    avatarUrlMediumRes: pngToDataUri(lowRes),
+    avatarUrlHighRes: highRes.toString('base64'),
+    avatarUrlLowRes: mediumRes.toString('base64'),
+    avatarUrlMediumRes: lowRes.toString('base64'),
   }
 }

--- a/src/renders/circles.ts
+++ b/src/renders/circles.ts
@@ -1,7 +1,5 @@
-import { Buffer } from 'node:buffer'
-import { round } from '../processing/image'
 import { generateBadge, SvgComposer } from '../processing/svg'
-import type { Sponsor, SponsorkitRenderer, Sponsorship } from '../types'
+import type { SponsorkitRenderer, Sponsorship } from '../types'
 
 export const circlesRenderer: SponsorkitRenderer = {
   name: 'sponsorkit:circles',

--- a/src/renders/circles.ts
+++ b/src/renders/circles.ts
@@ -67,11 +67,21 @@ async function getRoundedAvatars(sponsor: Sponsor) {
     return sponsor
 
   const data = base64ToArrayBuffer(sponsor.avatarBuffer)
+  const [
+    highRes,
+    mediumRes,
+    lowRes,
+  ] = await Promise.all([
+    round(data, 0.5, 120),
+    round(data, 0.5, 80),
+    round(data, 0.5, 50),
+  ])
+
   /// keep-sorted
   return {
     ...sponsor,
-    avatarUrlHighRes: pngToDataUri(await round(data, 0.5, 120)),
-    avatarUrlLowRes: pngToDataUri(await round(data, 0.5, 50)),
-    avatarUrlMediumRes: pngToDataUri(await round(data, 0.5, 80)),
+    avatarUrlHighRes: pngToDataUri(highRes),
+    avatarUrlLowRes: pngToDataUri(mediumRes),
+    avatarUrlMediumRes: pngToDataUri(lowRes),
   }
 }

--- a/src/renders/circles.ts
+++ b/src/renders/circles.ts
@@ -36,10 +36,10 @@ export const circlesRenderer: SponsorkitRenderer = {
     const circles = p(root as any).descendants().slice(1)
 
     for (const circle of circles) {
-      composer.addRaw(generateBadge(
+      composer.addRaw(await generateBadge(
         circle.x - circle.r,
         circle.y - circle.r,
-        await getRoundedAvatars(circle.data.sponsor),
+        circle.data.sponsor,
         {
           name: false,
           boxHeight: circle.r * 2,
@@ -48,6 +48,7 @@ export const circlesRenderer: SponsorkitRenderer = {
             size: circle.r * 2,
           },
         },
+        0.5,
       ))
     }
 
@@ -61,28 +62,4 @@ function lerp(a: number, b: number, t: number) {
   if (t < 0)
     return a
   return a + (b - a) * t
-}
-
-async function getRoundedAvatars(sponsor: Sponsor) {
-  if (!sponsor.avatarBuffer || sponsor.type === 'User')
-    return sponsor
-
-  const data = Buffer.from(sponsor.avatarBuffer, 'base64')
-  const [
-    highRes,
-    mediumRes,
-    lowRes,
-  ] = await Promise.all([
-    round(data, 0.5, 120),
-    round(data, 0.5, 80),
-    round(data, 0.5, 50),
-  ])
-
-  /// keep-sorted
-  return {
-    ...sponsor,
-    avatarUrlHighRes: highRes.toString('base64'),
-    avatarUrlLowRes: mediumRes.toString('base64'),
-    avatarUrlMediumRes: lowRes.toString('base64'),
-  }
 }

--- a/src/renders/circles.ts
+++ b/src/renders/circles.ts
@@ -1,4 +1,5 @@
-import { base64ToArrayBuffer, round } from '../processing/image'
+import { Buffer } from 'node:buffer'
+import { round } from '../processing/image'
 import { generateBadge, SvgComposer } from '../processing/svg'
 import type { Sponsor, SponsorkitRenderer, Sponsorship } from '../types'
 
@@ -66,7 +67,7 @@ async function getRoundedAvatars(sponsor: Sponsor) {
   if (!sponsor.avatarBuffer || sponsor.type === 'User')
     return sponsor
 
-  const data = base64ToArrayBuffer(sponsor.avatarBuffer)
+  const data = Buffer.from(sponsor.avatarBuffer, 'base64')
   const [
     highRes,
     mediumRes,

--- a/src/renders/tiers.ts
+++ b/src/renders/tiers.ts
@@ -17,31 +17,30 @@ export async function tiersComposer(composer: SvgComposer, sponsors: Sponsorship
 
   composer.addSpan(config.padding?.top ?? 20)
 
-  tierPartitions
-    .forEach(({ tier: t, sponsors }) => {
-      t.composeBefore?.(composer, sponsors, config)
-      if (t.compose) {
-        t.compose(composer, sponsors, config)
-      }
-      else {
-        const preset = t.preset || tierPresets.base
-        if (sponsors.length && preset.avatar.size) {
-          const paddingTop = t.padding?.top ?? 20
-          const paddingBottom = t.padding?.bottom ?? 10
-          if (paddingTop)
-            composer.addSpan(paddingTop)
-          if (t.title) {
-            composer
-              .addTitle(t.title)
-              .addSpan(5)
-          }
-          composer.addSponsorGrid(sponsors, preset)
-          if (paddingBottom)
-            composer.addSpan(paddingBottom)
+  for (const { tier: t, sponsors } of tierPartitions) {
+    t.composeBefore?.(composer, sponsors, config)
+    if (t.compose) {
+      t.compose(composer, sponsors, config)
+    }
+    else {
+      const preset = t.preset || tierPresets.base
+      if (sponsors.length && preset.avatar.size) {
+        const paddingTop = t.padding?.top ?? 20
+        const paddingBottom = t.padding?.bottom ?? 10
+        if (paddingTop)
+          composer.addSpan(paddingTop)
+        if (t.title) {
+          composer
+            .addTitle(t.title)
+            .addSpan(5)
         }
+        await composer.addSponsorGrid(sponsors, preset)
+        if (paddingBottom)
+          composer.addSpan(paddingBottom)
       }
-      t.composeAfter?.(composer, sponsors, config)
-    })
+    }
+    t.composeAfter?.(composer, sponsors, config)
+  }
 
   composer.addSpan(config.padding?.bottom ?? 20)
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,7 +9,7 @@ import c from 'picocolors'
 import type { Buffer } from 'node:buffer'
 import { version } from '../package.json'
 import { loadConfig } from './configs'
-import { resolveAvatars, svgToPng } from './processing/image'
+import { resolveAvatars, svgToPng, svgToWebp } from './processing/image'
 import { guessProviders, resolveProviders } from './providers'
 import { builtinRenderers } from './renders'
 import { outputFormats } from './types'
@@ -286,6 +286,10 @@ export async function applyRenderer(
         let data: string | Buffer = svg
         if (format === 'png') {
           data = await svgToPng(svg)
+        }
+
+        if (format === 'webp') {
+          data = await svgToWebp(svg)
         }
 
         await fsp.writeFile(path, data)

--- a/src/run.ts
+++ b/src/run.ts
@@ -8,6 +8,7 @@ import { consola } from 'consola'
 import c from 'picocolors'
 import type { Buffer } from 'node:buffer'
 import { version } from '../package.json'
+import { parseCache, stringifyCache } from './cache'
 import { loadConfig } from './configs'
 import { resolveAvatars, svgToPng, svgToWebp } from './processing/image'
 import { guessProviders, resolveProviders } from './providers'
@@ -202,10 +203,10 @@ export async function run(inlineConfig?: SponsorkitConfig, t = consola) {
     t.success('Avatars resolved')
 
     await fsp.mkdir(dirname(cacheFile), { recursive: true })
-    await fsp.writeFile(cacheFile, JSON.stringify(allSponsors, null, 2))
+    await fsp.writeFile(cacheFile, stringifyCache(allSponsors))
   }
   else {
-    allSponsors = JSON.parse(await fsp.readFile(cacheFile, 'utf-8'))
+    allSponsors = parseCache(await fsp.readFile(cacheFile, 'utf8'))
     t.success(`Loaded from cache ${r(cacheFile)}`)
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,10 +35,7 @@ export interface Sponsor {
   login: string
   name: string
   avatarUrl: string
-  avatarBuffer?: string
-  avatarUrlHighRes?: string
-  avatarUrlMediumRes?: string
-  avatarUrlLowRes?: string
+  avatarBuffer?: Buffer
   websiteUrl?: string
   linkUrl?: string
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,7 +72,9 @@ export interface Sponsorship {
   raw?: any
 }
 
-export type OutputFormat = 'svg' | 'png' | 'json'
+export const outputFormats = ['svg', 'png', 'json'] as const
+
+export type OutputFormat = typeof outputFormats[number]
 
 export type ProviderName = 'github' | 'patreon' | 'opencollective' | 'afdian' | 'polar'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,7 +72,7 @@ export interface Sponsorship {
   raw?: any
 }
 
-export const outputFormats = ['svg', 'png', 'json'] as const
+export const outputFormats = ['svg', 'png', 'webp', 'json'] as const
 
 export type OutputFormat = typeof outputFormats[number]
 


### PR DESCRIPTION
> [!IMPORTANT]
> This is a PR against https://github.com/antfu-collective/sponsorkit/pull/93
> Diff: https://github.com/privatenumber/sponsorkit/compare/webp-sharp...optimize-cache-more
> https://github.com/antfu-collective/sponsorkit/pull/93 should be merged first

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

- We never need all 3 resolutions for an image so it was wasteful to be processing all 3 image sizes for every avatar
- It was also wasteful to store them in the cache

- Now, it only stores the highest resolution we need in the cache, and we process the image size we need as we use them. There's a cache to prevent re-computation.

- I was able to slim down the code as well because we now no longer need to manage all 3 sizes
- I also created a cache parser/stringifier to abstract out the buffer <-> base64 conversion

#### Results
- Old cache size: `2.6 MB`
- New cache size: `931 KB`

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
