### PR TITLE
perf: embed webp in svg output

### DIFF
--- a/src/renders/circles.ts
+++ b/src/renders/circles.ts
@@ -47,6 +47,7 @@ export const circlesRenderer: SponsorkitRenderer = {
           },
         },
         0.5,
+        config.imageFormat,
       ))
     }
 

--- a/src/renders/tiers.ts
+++ b/src/renders/tiers.ts
@@ -3,15 +3,6 @@ import { tierPresets } from '../configs/tier-presets'
 import { SvgComposer } from '../processing/svg'
 import type { SponsorkitConfig, SponsorkitRenderer, Sponsorship } from '../types'
 
-export const tiersRenderer: SponsorkitRenderer = {
-  name: 'sponsorkit:tiers',
-  async renderSVG(config, sponsors) {
-    const composer = new SvgComposer(config)
-    await (config.customComposer || tiersComposer)(composer, sponsors, config)
-    return composer.generateSvg()
-  },
-}
-
 export async function tiersComposer(composer: SvgComposer, sponsors: Sponsorship[], config: SponsorkitConfig) {
   const tierPartitions = partitionTiers(sponsors, config.tiers!, config.includePastSponsors)
 
@@ -43,4 +34,13 @@ export async function tiersComposer(composer: SvgComposer, sponsors: Sponsorship
   }
 
   composer.addSpan(config.padding?.bottom ?? 20)
+}
+
+export const tiersRenderer: SponsorkitRenderer = {
+  name: 'sponsorkit:tiers',
+  async renderSVG(config, sponsors) {
+    const composer = new SvgComposer(config)
+    await (config.customComposer || tiersComposer)(composer, sponsors, config)
+    return composer.generateSvg()
+  },
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,8 @@
 import type { Buffer } from 'node:buffer'
 import type { SvgComposer } from './processing/svg'
 
+export type ImageFormat = 'png' | 'webp'
+
 export interface BadgePreset {
   boxWidth: number
   boxHeight: number
@@ -280,6 +282,13 @@ export interface SponsorkitRenderOptions {
    * @default auto detect based on tiers
    */
   includePastSponsors?: boolean
+
+  /**
+   * Format of embedded images
+   *
+   * @default 'webp'
+   */
+  imageFormat?: ImageFormat
 
   /**
    * Hook to modify sponsors data before rendering.


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

- Store images in WebP by default (previously PNG). This reduces cache size.
- SVGs embed WebP, reducing SVG file size
- PNG & WebP output formats re-generate SVGs with PNGs because sharp only supports rendering PNGs inside SVGs


#### Performance improvements

##### Cache size
- Before: `991 KB`
- After: `381 KB`

##### Tiers SVG

| Before (`320 KB`) | After (`148 KB`) |
| - | - |
|  ![sponsors](https://github.com/user-attachments/assets/e9b24af3-b255-43c3-a14c-d4dc0380827d) |  ![sponsors](https://github.com/user-attachments/assets/a23ddf9a-6f8c-4ab0-8510-8934699b0a0c) |

##### Circles SVG

| Before (`431 KB`) | After (`197 KB`) |
| - | - |
| ![sponsors](https://github.com/user-attachments/assets/ac6974b3-8f7a-427b-a959-ef86fc0968a0) |  ![sponsors](https://github.com/user-attachments/assets/1181b7c2-d4f5-4102-851b-fa38e942bd23) |

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
