### PR TITLE
fix: try-catch url parsing

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,12 @@ export function normalizeUrl(url: string | undefined): string | undefined {
   if (!url)
     return undefined
 
-  return _normalizeUrl(url, {
-    defaultProtocol: 'https',
-  })
+  try {
+    return _normalizeUrl(url, {
+      defaultProtocol: 'https',
+    })
+  }
+  catch {
+    return url
+  }
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

- If a user has an invalid URL, the script can break when it fails to parse it:
	https://github.com/antfu/static/actions/runs/11698720591/job/32579476304

	In this example, the invalid URL string is `'https:felixgraf.dev (WIP)'`

- Adding a try-catch to prevent parsing errors
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
