### PR TITLE
fix: handle `json` format

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -298,7 +298,7 @@ export async function applyRenderer(
 
         let data: string | Buffer
 
-        if (format === 'svg') {
+        if (format === 'svg' || format === 'json') {
           data = await processingSvg
         }
 


### PR DESCRIPTION
### Description

This PR tries to fix #98 based on my limited knowledge of the codebase. Feel free to update directly the PR or close it if this was not the right fix/thing to do :)

I managed to replicate my issue directly in the `example` directory with my login and sponsors, without changing the `sponsor.config.ts` file. Here's the result when I run `pnpm run build:dev` in this directory with my GH login:

```
Scope: all 2 workspace projects
Done in 745ms

> @ build:dev /Users/ju/sponsorkit/example
> esno ../src/cli.ts

                                                                                                                                         2:54:02 PM
SponsorKit v0.16.1

✔ Loaded from cache ./sponsorkit/.cache.json                                                                                            2:54:02 PM
ℹ Generating with 3 renders...                                                                                                          2:54:02 PM
ℹ [sponsors] Composing SVG...                                                                                                           2:54:02 PM
ℹ [sponsors-wide] Composing SVG...                                                                                                      2:54:02 PM
✔ [sponsors-circles] Wrote to ./sponsorkit/sponsors-circles.json                                                                        2:54:02 PM
ℹ [sponsors-circles] Composing SVG...                                                                                                   2:54:02 PM
node:internal/fs/promises:1049
    validateStringAfterArrayBufferView(data, 'data');
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received undefined
    at Object.writeFile (node:internal/fs/promises:1049:5)
    at <anonymous> (/Users/ju/sponsorkit/src/run.ts:324:19)
    at Array.map (<anonymous>)
    at applyRenderer (/Users/ju/sponsorkit/src/run.ts:293:29)
    at <anonymous> (/Users/ju/sponsorkit/src/run.ts:230:7)
    at async Promise.all (index 2)
    at run (/Users/ju/sponsorkit/src/run.ts:224:5)
    at Object.handler (/Users/ju/sponsorkit/src/cli.ts:55:5) {
  code: 'ERR_INVALID_ARG_TYPE'
}

Node.js v20.12.2
 ELIFECYCLE  Command failed with exit code 1.
```

With the modification of this PR, the images are well generated. So it might not be as I thought in the issue that the `formats` option is mandatory, but rather than by default there's `json` in it, and it crashes in the middle of the algorithm.

After having added a lot of logs, I managed to find out that `data` is undefined because the format is `json` at this moment. Since it's not `svg`, `png`, or `webp`, `data` is never filled out in the algorithm. So whenever the `path` was `/Users/ju/sponsorkit/example/sponsorkit/sponsors-circles.json`, the `data` was `undefined`.

Hopefully, it doesn't break any other use cases folks might have 😬 

### Linked Issues

Closes #98

### Additional context

I've also tested to change `sponsor.config.ts` to use the one in my project: https://raw.githubusercontent.com/julien-deramond/static/refs/heads/main/sponsorkit.config.ts, and it worked too.