### PR TITLE
feat: replace picocolors with ansis

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,13 +49,13 @@
   "dependencies": {
     "@antfu/utils": "^8.1.0",
     "@fast-csv/parse": "^5.0.2",
+    "ansis": "^3.12.0",
     "consola": "^3.4.0",
     "d3-hierarchy": "^3.1.2",
     "dotenv": "^16.4.7",
     "normalize-url": "^8.0.1",
     "ofetch": "^1.4.1",
     "p-limit": "^6.2.0",
-    "picocolors": "^1.1.1",
     "sharp": "^0.33.5",
     "unconfig": "^0.6.0",
     "yargs": "^17.7.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@fast-csv/parse':
         specifier: ^5.0.2
         version: 5.0.2
+      ansis:
+        specifier: ^3.12.0
+        version: 3.12.0
       consola:
         specifier: ^3.4.0
         version: 3.4.0
@@ -35,9 +38,6 @@ importers:
       p-limit:
         specifier: ^6.2.0
         version: 6.2.0
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
       sharp:
         specifier: ^0.33.5
         version: 0.33.5
@@ -1247,6 +1247,10 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansis@3.12.0:
+    resolution: {integrity: sha512-SxhlInpMkv9QCyI2yHyrhVrTF8dH93M/S86DT5f9brFgr92uJLOCg0RNmtx3YKWKcRmNAaU+gyUfHMdUiqxvFw==}
+    engines: {node: '>=14'}
 
   are-docs-informative@0.0.2:
     resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
@@ -4099,6 +4103,8 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansis@3.12.0: {}
 
   are-docs-informative@0.0.2: {}
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -5,8 +5,8 @@ import fsp from 'node:fs/promises'
 import { dirname, join, relative, resolve } from 'node:path'
 import process from 'node:process'
 import { notNullish } from '@antfu/utils'
+import c from 'ansis'
 import { consola } from 'consola'
-import c from 'picocolors'
 import { version } from '../package.json'
 import { parseCache, stringifyCache } from './cache'
 import { loadConfig } from './configs'
@@ -29,7 +29,7 @@ function r(path: string) {
 }
 
 export async function run(inlineConfig?: SponsorkitConfig, t = consola) {
-  t.log(`\n${c.magenta(c.bold('SponsorKit'))} ${c.dim(`v${version}`)}\n`)
+  t.log(`\n${c.magenta.bold`SponsorKit`} ${c.dim`v${version}`}\n`)
 
   const fullConfig = await loadConfig(inlineConfig)
   const config = fullConfig as Required<SponsorkitMainConfig>
@@ -157,7 +157,7 @@ export async function run(inlineConfig?: SponsorkitConfig, t = consola) {
         const sorted = [...group]
           .sort((a, b) => allSponsors.indexOf(a) - allSponsors.indexOf(b))
 
-        t.info(`Merging ${sorted.map(i => c.cyan(`@${i.sponsor.login}(${i.provider})`)).join(' + ')}`)
+        t.info(`Merging ${sorted.map(i => c.cyan`@${i.sponsor.login}(${i.provider})`).join(' + ')}`)
 
         for (const s of sorted.slice(1))
           removeSponsors.add(s)
@@ -257,7 +257,7 @@ export async function applyRenderer(
   sponsors = [...sponsors]
   sponsors = await renderOptions.onBeforeRenderer?.(sponsors) || sponsors
 
-  const logPrefix = c.dim(`[${renderOptions.name}]`)
+  const logPrefix = c.dim`[${renderOptions.name}]`
   const dir = resolve(process.cwd(), config.outputDir)
   await fsp.mkdir(dir, { recursive: true })
   if (renderOptions.formats?.includes('json')) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Hello @antfu,

This PR replaces `picocolors` with a better alternative `ansis` that supports both CJS and ESM.
Ansis supports chained syntax for clean and readable code.
Ansis is nearly as small (6.8 kB) as Picocolors (6.4 kB).
