### PR TITLE
fix: svg overwrite json

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -260,11 +260,6 @@ export async function applyRenderer(
   const logPrefix = c.dim`[${renderOptions.name}]`
   const dir = resolve(process.cwd(), config.outputDir)
   await fsp.mkdir(dir, { recursive: true })
-  if (renderOptions.formats?.includes('json')) {
-    const path = join(dir, `${renderOptions.name}.json`)
-    await fsp.writeFile(path, JSON.stringify(sponsors, null, 2))
-    t.success(`${logPrefix} Wrote to ${r(path)}`)
-  }
 
   if (renderOptions.filter)
     sponsors = sponsors.filter(s => renderOptions.filter(s, sponsors) !== false)
@@ -273,8 +268,6 @@ export async function applyRenderer(
 
   if (!renderOptions.imageFormat)
     renderOptions.imageFormat = 'webp'
-
-  t.info(`${logPrefix} Composing SVG...`)
 
   const processingSvg = (async () => {
     let svgWebp = await renderer.renderSVG(renderOptions, sponsors)
@@ -297,8 +290,13 @@ export async function applyRenderer(
 
         let data: string | Buffer
 
-        if (format === 'svg' || format === 'json') {
+        if (format === 'svg') {
+          t.info(`${logPrefix} Composing SVG...`)
           data = await processingSvg
+        }
+
+        if (format ==='json') {
+          data = JSON.stringify(sponsors, null, 2)
         }
 
         if (format === 'png' || format === 'webp') {

--- a/src/run.ts
+++ b/src/run.ts
@@ -295,7 +295,7 @@ export async function applyRenderer(
           data = await processingSvg
         }
 
-        if (format ==='json') {
+        if (format === 'json') {
           data = JSON.stringify(sponsors, null, 2)
         }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

#### 1. svg override the json file

When `format` contains `json` and `svg`, the content of svg will overwrite the content of json.

before:

![PixPin_2025-02-21_22-06-50](https://github.com/user-attachments/assets/6dec675f-f61c-4245-a7b0-3f294a0cf7f2)


after: 

![image](https://github.com/user-attachments/assets/a5a35ccc-f57e-4c1d-9cbd-89545f87de34)

#### 2. fix log

There should be no logging of 'compressing svg' when `svg` is not included in the `format`.

before:

![PixPin_2025-02-21_22-08-23](https://github.com/user-attachments/assets/b9414125-3ff3-4f6a-8498-8675cce6ff0c)

after:

![PixPin_2025-02-21_22-09-37](https://github.com/user-attachments/assets/9c65894f-cb18-43a6-8d06-8c2e7f7f95c4)

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

may ref: #99
