### PR TITLE
fix: incorrect shows the tier for the user with a gifted membership for Patreon

### DIFF
--- a/src/providers/patreon.ts
+++ b/src/providers/patreon.ts
@@ -27,7 +27,7 @@ export async function fetchPatreonSponsors(token: string): Promise<Sponsorship[]
   const userCampaignId = userData.data[0].id
 
   const sponsors: any[] = []
-  let sponsorshipApi = `https://www.patreon.com/api/oauth2/v2/campaigns/${userCampaignId}/members?include=user&fields%5Bmember%5D=currently_entitled_amount_cents,patron_status,pledge_relationship_start,lifetime_support_cents&fields%5Buser%5D=image_url,url,first_name,full_name&page%5Bcount%5D=100`
+  let sponsorshipApi = `https://www.patreon.com/api/oauth2/v2/campaigns/${userCampaignId}/members?include=user,currently_entitled_tiers&fields%5Bmember%5D=currently_entitled_amount_cents,patron_status,pledge_relationship_start,lifetime_support_cents&fields%5Buser%5D=image_url,url,first_name,full_name&fields%5Btier%5D=amount_cents&page%5Bcount%5D=100`
   do {
     // Get pledges from the campaign
     const sponsorshipData = await $fetch(sponsorshipApi, {
@@ -45,15 +45,18 @@ export async function fetchPatreonSponsors(token: string): Promise<Sponsorship[]
         .map((membership: any) => ({
           membership,
           patron: sponsorshipData.included.find(
-            (v: any) => v.id === membership.relationships.user.data.id,
+            (v: any) => v.type === 'user' && v.id === membership.relationships.user.data.id,
+          ),
+          tier: sponsorshipData.included.find(
+            (v: any) => v.type === 'tier' && v.id === membership.relationships.currently_entitled_tiers.data[0]?.id,
           ),
         })),
     )
     sponsorshipApi = sponsorshipData.links?.next
   } while (sponsorshipApi)
 
-  const processed = sponsors.map(
-    (raw: any): Sponsorship => ({
+  const processed = sponsors.map((raw: any): Sponsorship => {
+    const sponsor: Sponsorship = {
       sponsor: {
         avatarUrl: raw.patron.attributes.image_url,
         login: raw.patron.attributes.first_name,
@@ -62,13 +65,21 @@ export async function fetchPatreonSponsors(token: string): Promise<Sponsorship[]
         linkUrl: raw.patron.attributes.url,
       },
       isOneTime: false, // One-time pledges not supported
-      // The "former_patron" and "declined_patron" both is past sponsors
-      monthlyDollars: ['former_patron', 'declined_patron'].includes(raw.membership.attributes.patron_status) ? -1 : Math.floor(raw.membership.attributes.currently_entitled_amount_cents / 100),
+      monthlyDollars: Math.floor(raw.membership.attributes.currently_entitled_amount_cents / 100),
       privacyLevel: 'PUBLIC', // Patreon is all public
       tierName: 'Patreon',
       createdAt: raw.membership.attributes.pledge_relationship_start,
-    }),
-  )
+    }
+
+    // The "former_patron" and "declined_patron" both is past sponsors
+    if (['former_patron', 'declined_patron'].includes(raw.membership.attributes.patron_status))
+      sponsor.monthlyDollars = -1
+    // If the sponsor is not a patron but has a gifted membership, we can still show the tier amount
+    else if (sponsor.monthlyDollars <= 0 && (raw.tier?.attributes.amount_cents || 0) > 0)
+      sponsor.monthlyDollars = Math.floor(raw.tier.attributes.amount_cents / 100)
+
+    return sponsor
+  })
 
   return processed
 }


### PR DESCRIPTION
### Description

The background is my Patreon memberships have someone who has a gifted membership is `Generous Backer` tier, but shows the member into the `Backers` tier in the generated sponsors image:

![sponsors-unfix](https://github.com/user-attachments/assets/b7c55e18-b2eb-4e03-92b1-11d6a38b8def)

Because he has a gifted tier, and there is no investment money.

And this is my expected result:

![sponsors-fixed](https://github.com/user-attachments/assets/7beb79dc-3de5-4c8d-94d7-36a11a4e093b)

Therefore, this PR adds a confirmation that if the member's `monthlyDollars` is 0, the member's tier amount will be automatically obtained.

### Linked Issues


### Additional context

[How to gift memberships to other fans &ndash; Patreon Help Center](https://support.patreon.com/hc/en-us/articles/31344987943949-How-to-gift-memberships-to-other-fans)

Reference Patreon API: https://docs.patreon.com/#get-api-oauth2-v2-campaigns-campaign_id-members
