### PR TITLE
fix: hide dotenv logs

### DIFF
--- a/src/configs/env.ts
+++ b/src/configs/env.ts
@@ -10,7 +10,7 @@ function getDeprecatedEnv(name: string, replacement: string) {
 }
 
 export function loadEnv(): Partial<SponsorkitConfig> {
-  dotenv.config()
+  dotenv.config({ quiet: true })
 
   const config: Partial<SponsorkitConfig> = {
     github: {


### PR DESCRIPTION


- [x] <- Keep this line and put an `x` between the brackts.

### Description

Right now dotenv logs these kinds of tips / ads:

> [dotenv@17.2.2] injecting env (3) from .env -- tip: 📡 observe env with Radar: https://dotenvx.com/radar

> [dotenv@17.2.2] injecting env (3) from .env -- tip: ⚙️  specify custom .env file path with { path: '/custom/path/.env' }

This PR removes them by passing `quiet: true`

### Linked Issues

n/a

### Additional context

n/a
