### PR TITLE
fix: hoist `RE_FILTER`

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import cac from 'cac'
 import { version } from '../package.json'
 import { run } from './run'
 
+const RE_FILTER = /([<>=]+)(\d+)/
 const cli = cac('sponsors-svg')
   .version(version)
   .help()
@@ -28,8 +29,6 @@ cli
   })
 
 cli.parse()
-
-const RE_FILTER = /([<>=]+)(\d+)/
 
 /**
  * Create filter function from templates like


### PR DESCRIPTION
### 🔗 Linked issue

Closes #118 

### 🧭 Context

After having analyzed the issue, it seems to come from https://github.com/antfu-collective/sponsorkit/commit/7e4ea1b75614487c1ea7acaa732a5be0db0e2d5a where `RE_FILTER` is used before it's even created.

### 📚 Description

This PR simply declares `RE_FILTER` before the function using it is called: `createFilterFromString`. Indeed, the CLI would call `createFilterFromString()` line 25/26.

### Testing

1. `pnpm i ; pnpm build`
2. `cd example`
3. `pnpm i`
4. Copy your `.env` in this dir
5. Run `node_modules/.bin/sponsorkit --dir=. -w=800 --name=sponsors.part2 --filter="<9.9"`

It now works.