### PR TITLE
fix: handle GraphQL errors from OpenCollective API

### DIFF
--- a/src/providers/opencollective.ts
+++ b/src/providers/opencollective.ts
@@ -67,10 +67,10 @@ export async function fetchOpenCollectiveSponsors(
       if (errors?.length) {
         throw new Error(`OpenCollective subscriptions query errors: ${errors.map((e: Error) => e.message).join('; ')}`)
       }
-      const nodes = data.account.orders.nodes
+      const nodes = data.account.orders.nodes || []
       const totalCount = data.account.orders.totalCount
 
-      sponsors.push(...(nodes || []))
+      sponsors.push(...nodes)
 
       if ((nodes.length) !== 0) {
         if (totalCount > offset + nodes.length)
@@ -100,10 +100,10 @@ export async function fetchOpenCollectiveSponsors(
     if (errors?.length) {
       throw new Error(`OpenCollective transactions query errors: ${errors.map((e: Error) => e.message).join('; ')}`)
     }
-    const nodes = data.account.transactions.nodes
+    const nodes = data.account.transactions.nodes || []
     const totalCount = data.account.transactions.totalCount
 
-    monthlyTransactions.push(...(nodes || []))
+    monthlyTransactions.push(...nodes)
     if ((nodes.length) !== 0) {
       if (totalCount > offset + nodes.length)
         offset += nodes.length

--- a/src/providers/opencollective.ts
+++ b/src/providers/opencollective.ts
@@ -56,16 +56,19 @@ export async function fetchOpenCollectiveSponsors(
     offset = 0
     do {
       const query = makeSubscriptionsQuery(id, slug, githubHandle, offset, !includePastSponsors)
-      const data = await $fetch(API, {
+      const { data, errors } = await $fetch(API, {
         method: 'POST',
         body: { query },
         headers: {
           'Api-Key': `${key}`,
           'Content-Type': 'application/json',
         },
-      }) as any
-      const nodes = data.data.account.orders.nodes
-      const totalCount = data.data.account.orders.totalCount
+      })
+      if (errors?.length) {
+        throw new Error(`OpenCollective subscriptions query errors: ${errors.map((e: Error) => e.message).join('; ')}`)
+      }
+      const nodes = data.account.orders.nodes
+      const totalCount = data.account.orders.totalCount
 
       sponsors.push(...(nodes || []))
 
@@ -86,16 +89,19 @@ export async function fetchOpenCollectiveSponsors(
       ? undefined
       : new Date(now.getFullYear(), now.getMonth(), 1)
     const query = makeTransactionsQuery(id, slug, githubHandle, offset, dateFrom, undefined, sponseesMode)
-    const data = await $fetch(API, {
+    const { data, errors } = await $fetch(API, {
       method: 'POST',
       body: { query },
       headers: {
         'Api-Key': `${key}`,
         'Content-Type': 'application/json',
       },
-    }) as any
-    const nodes = data.data.account.transactions.nodes
-    const totalCount = data.data.account.transactions.totalCount
+    })
+    if (errors?.length) {
+      throw new Error(`OpenCollective transactions query errors: ${errors.map((e: Error) => e.message).join('; ')}`)
+    }
+    const nodes = data.account.transactions.nodes
+    const totalCount = data.account.transactions.totalCount
 
     monthlyTransactions.push(...(nodes || []))
     if ((nodes.length) !== 0) {


### PR DESCRIPTION
## Summary

- Destructure `errors` from OpenCollective GraphQL responses in both subscriptions and transactions queries, missing permission scope for example
- Throw descriptive errors when GraphQL errors are present, instead of silently ignoring them

## Test plan

- [x] TypeScript compiles cleanly
- [ ] Manual run against OpenCollective API